### PR TITLE
feat: add bond object to v1 client

### DIFF
--- a/client/bond.go
+++ b/client/bond.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"fmt"
+)
+
+type Bond struct {
+	Master string `json:"master"`
+	Mode   string `json:"mode"`
+	Id     string `json:"id"`
+	Uuid   string `json:"uuid"`
+	PoolId string `json:"$poolId"`
+}
+
+func (b Bond) Compare(obj interface{}) bool {
+	other, ok := obj.(Bond)
+	if !ok {
+		return false
+	}
+	if b.Id != "" && b.Id == other.Id {
+		return true
+	}
+	if b.PoolId != "" && b.PoolId == other.PoolId {
+		return false
+	}
+	if b.Master != "" && b.Master != other.Master {
+		return false
+	}
+	if b.Mode != "" && b.Mode != other.Mode {
+		return false
+	}
+	if b.Uuid != "" && b.Uuid != other.Uuid {
+		return false
+	}
+	return true
+}
+
+func (c *Client) GetBond(bondReq Bond) (*Bond, error) {
+	obj, err := c.FindFromGetAllObjects(bondReq)
+	if err != nil {
+		return nil, err
+	}
+	bonds := obj.([]Bond)
+	if len(bonds) != 1 {
+		return nil, fmt.Errorf("expected to find a single Bond from request %+v, instead found %d", bondReq.Id, len(bonds))
+	}
+	return &bonds[0], nil
+}
+
+func (c *Client) GetBonds(bondReq Bond) ([]Bond, error) {
+	obj, err := c.FindFromGetAllObjects(bondReq)
+	if err != nil {
+		return nil, err
+	}
+	bonds := obj.([]Bond)
+	return bonds, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -132,6 +132,9 @@ type XOClient interface {
 	GetCdroms(vm *Vm) ([]Disk, error)
 	EjectCd(id string) error
 	InsertCd(vmId, cdId string) error
+
+	GetBond(bondReq Bond) (*Bond, error)
+	GetBonds(bondReq Bond) ([]Bond, error)
 }
 
 type Client struct {
@@ -405,6 +408,8 @@ func (c *Client) getObjectTypeFilter(obj XoObject) map[string]interface{} {
 		xoApiType = "VBD"
 	case VDI:
 		xoApiType = "VDI"
+	case Bond:
+		xoApiType = "bond"
 	default:
 		panic(fmt.Sprintf("XO client does not support type: %T", t))
 	}

--- a/client/pif.go
+++ b/client/pif.go
@@ -7,16 +7,18 @@ import (
 )
 
 type PIF struct {
-	Device       string `json:"device"`
-	Host         string `json:"$host"`
-	Network      string `json:"$network"`
-	Id           string `json:"id"`
-	Uuid         string `json:"uuid"`
-	PoolId       string `json:"$poolId"`
-	Attached     bool   `json:"attached"`
-	Vlan         int    `json:"vlan"`
-	IsBondMaster bool   `json:"isBondMaster,omitempty"`
-	IsBondSlave  bool   `json:"isBondSlave,omitempty"`
+	Device       string   `json:"device"`
+	Host         string   `json:"$host"`
+	Network      string   `json:"$network"`
+	Id           string   `json:"id"`
+	Uuid         string   `json:"uuid"`
+	PoolId       string   `json:"$poolId"`
+	Attached     bool     `json:"attached"`
+	Vlan         int      `json:"vlan"`
+	IsBondMaster bool     `json:"isBondMaster,omitempty"`
+	IsBondSlave  bool     `json:"isBondSlave,omitempty"`
+	BondSlaves   []string `json:"bondSlaves,omitempty"`
+	BondMaster   string   `json:"bondMaster,omitempty"`
 }
 
 func (p PIF) Compare(obj interface{}) bool {


### PR DESCRIPTION
In order to fix https://github.com/vatesfr/terraform-provider-xenorchestra/issues/346, we need the Bond object containing the BondMode property, as well as the BondSlaves property of the master PIF of the bonded network.