### PR TITLE
feat: add CoresPerSocket field for VM CPU topology configuration

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -118,6 +118,7 @@ type Vm struct {
 	NameDescription    string                 `json:"name_description"`
 	NameLabel          string                 `json:"name_label"`
 	CPUs               CPUs                   `json:"CPUs"`
+	CoresPerSocket     *int                   `json:"coresPerSocket,omitempty"`
 	ExpNestedHvm       bool                   `json:"expNestedHvm,omitempty"`
 	Memory             MemoryObject           `json:"memory"`
 	PowerState         string                 `json:"power_state"`
@@ -411,6 +412,10 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	if cloudNetworkConfig != "" {
 		params["networkConfig"] = cloudNetworkConfig
 	}
+
+	if vmReq.CoresPerSocket != nil {
+		params["coresPerSocket"] = *vmReq.CoresPerSocket
+	}
 	c.logger.Debug("VM params for vm.create", "param", params)
 	var vmId string
 	err = c.Call("vm.create", params, &vmId)
@@ -553,6 +558,10 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		}
 	}
 	params["blockedOperations"] = blockedOperations
+
+	if vmReq.CoresPerSocket != nil {
+		params["coresPerSocket"] = *vmReq.CoresPerSocket
+	}
 
 	c.logger.Debug("VM params for vm.set", "params", params)
 


### PR DESCRIPTION
## Description

This PR adds support for configuring CPU topology using the `coresPerSocket` parameter in the XO API. 

### Background

When creating VMs with Terraform, users currently cannot control CPU topology (number of cores per socket). VMs inherit this setting from the template, and XO increases the number of sockets to match the requested CPU count. In some cases, this can cause performance issues inside the guest OS, particularly around NUMA behavior and CPU scheduling.

### Changes

- Added a `CoresPerSocket` field (`*int`) to the `Vm` struct
- Updated `CreateVm` to include the `coresPerSocket` parameter when creating VMs
- Updated `UpdateVm` to include the `coresPerSocket` parameter when updating VMs
- The field is a pointer to clearly distinguish between an unset value and one that is explicitly defined

### API Notes

The XO API supports the `coresPerSocket` parameter for both VM creation and updates:
- `vm.create`
- `vm.set`

### Testing

- Build verification passed
- extensive Integration testing with the provider is pending, i mean we'll probably need feedbacks from other users
Tested locally using the Terraform provider:
- Creating VMs with a custom `cores_per_socket` value
- Updating existing VMs to modify `cores_per_socket`
- Verifying the value is correctly applied and persisted

### Related

This unblocks CPU topology configuration in the Terraform provider  
(vatesfr/terraform-provider-xenorchestra#378).
