### PR TITLE
Feat/add empty vdi creation service in go sdk v2

### DIFF
--- a/pkg/payloads/common.go
+++ b/pkg/payloads/common.go
@@ -1,0 +1,7 @@
+package payloads
+
+import "github.com/gofrs/uuid"
+
+type CreateResponse struct {
+	ID uuid.UUID `json:"id"`
+}

--- a/pkg/payloads/vdi.go
+++ b/pkg/payloads/vdi.go
@@ -74,3 +74,17 @@ const (
 	VDIOperationSnapshot          VDIOperation = "snapshot"
 	VDIOperationUpdate            VDIOperation = "update"
 )
+
+type VDICreateParams struct {
+	SRId            uuid.UUID         `json:"srId"`
+	VirtualSize     int64             `json:"virtual_size"`
+	NameDescription string            `json:"name_description,omitempty"`
+	NameLabel       string            `json:"name_label,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	VDIType         VDIType           `json:"type,omitempty"`
+	OtherConfig     map[string]string `json:"other_config,omitempty"`
+	ReadOnly        *bool             `json:"read_only,omitempty"`
+	Sharable        *bool             `json:"sharable,omitempty"`
+	XenstoreData    map[string]string `json:"xenstore_data,omitempty"`
+	SmConfig        map[string]any    `json:"sm_config,omitempty"`
+}

--- a/pkg/services/vdi/service.go
+++ b/pkg/services/vdi/service.go
@@ -188,3 +188,17 @@ func (s *Service) Import(
 
 	return nil
 }
+
+func (s *Service) Create(ctx context.Context, params payloads.VDICreateParams) (uuid.UUID, error) {
+	path := core.NewPathBuilder().Resource(vdiResourcePath).Build()
+
+	var result payloads.CreateResponse
+
+	err := client.TypedPost(ctx, s.client, path, params, &result)
+	if err != nil {
+		s.log.Error("Failed to create VDI", zap.Any("params", params), zap.Error(err))
+		return uuid.Nil, err
+	}
+
+	return result.ID, nil
+}

--- a/pkg/services/vdi/service.go
+++ b/pkg/services/vdi/service.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	vdiResourcePath = "vdis"
+)
+
 type Service struct {
 	client      *client.Client
 	log         *logger.Logger
@@ -41,7 +45,7 @@ func (s *Service) RemoveTag(ctx context.Context, id uuid.UUID, tag string) error
 
 func (s *Service) Get(ctx context.Context, id uuid.UUID) (*payloads.VDI, error) {
 	var result payloads.VDI
-	path := core.NewPathBuilder().Resource("vdis").ID(id).Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).Build()
 	err := client.TypedGet(
 		ctx,
 		s.client,
@@ -57,7 +61,7 @@ func (s *Service) Get(ctx context.Context, id uuid.UUID) (*payloads.VDI, error) 
 }
 
 func (s *Service) GetAll(ctx context.Context, limit int, filter string) ([]*payloads.VDI, error) {
-	path := core.NewPathBuilder().Resource("vdis").Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).Build()
 	params := make(map[string]any)
 	if limit > 0 {
 		params["limit"] = limit
@@ -78,7 +82,7 @@ func (s *Service) GetAll(ctx context.Context, limit int, filter string) ([]*payl
 }
 
 func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
-	path := core.NewPathBuilder().Resource("vdis").ID(id).Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).Build()
 
 	var result struct{}
 
@@ -91,7 +95,7 @@ func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 func (s *Service) Migrate(ctx context.Context, id uuid.UUID, srId uuid.UUID) (string, error) {
-	path := core.NewPathBuilder().Resource("vdis").ID(id).ActionsGroup().Action("migrate").Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).ActionsGroup().Action("migrate").Build()
 
 	var result payloads.TaskIDResponse
 
@@ -115,7 +119,7 @@ func (s *Service) Migrate(ctx context.Context, id uuid.UUID, srId uuid.UUID) (st
 }
 
 func (s *Service) GetTasks(ctx context.Context, id uuid.UUID, limit int, filter string) ([]*payloads.Task, error) {
-	path := core.NewPathBuilder().Resource("vdis").ID(id).Resource("tasks").Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).Resource("tasks").Build()
 
 	params := make(map[string]any)
 	params["fields"] = "*"
@@ -145,7 +149,7 @@ func (s *Service) Export(ctx context.Context, id uuid.UUID, format payloads.VDIF
 		return fmt.Errorf("callback function cannot be nil")
 	}
 
-	path := core.NewPathBuilder().Resource("vdis").ID(id).Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).Build()
 	endpoint := fmt.Sprintf("%s.%s", path, format)
 
 	resp, err := client.RawGet(ctx, s.client, endpoint)
@@ -171,7 +175,7 @@ func (s *Service) Import(
 		return fmt.Errorf("size must be greater than 0")
 	}
 
-	path := core.NewPathBuilder().Resource("vdis").ID(id).Build()
+	path := core.NewPathBuilder().Resource(vdiResourcePath).ID(id).Build()
 	endpoint := fmt.Sprintf("%s.%s", path, format)
 
 	resp, err := client.RawPut(ctx, s.client, endpoint, content, "application/octet-stream", size)

--- a/pkg/services/vdi/service_test.go
+++ b/pkg/services/vdi/service_test.go
@@ -212,6 +212,40 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		}
 	})
 
+	// POST /rest/v0/vdis - Create a VDI
+	mux.HandleFunc("POST /rest/v0/vdis", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var params payloads.VDICreateParams
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if params.SRId.String() != testSRID ||
+			params.NameLabel != testVDINameLabel1 ||
+			params.VirtualSize != testVDIVirtualSize {
+			errorMessage := fmt.Sprintf("invalid parameters,\n"+
+				"expected srId: %s, name: %s, virtualSize: %d,\n"+
+				"got srId: %s, name: %s, virtualSize: %d",
+				testSRID,
+				testVDINameLabel1,
+				testVDIVirtualSize,
+				params.SRId.String(),
+				params.NameLabel,
+				params.VirtualSize,
+			)
+			http.Error(w, errorMessage, http.StatusBadRequest)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(payloads.CreateResponse{
+			ID: uuid.Must(uuid.FromString(testVDIID1)),
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
 	// POST /rest/v0/vdis/{id}/actions/migrate - Migrate VDI
 	mux.HandleFunc("POST /rest/v0/vdis/{id}/actions/migrate", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -706,5 +740,63 @@ func TestImport(t *testing.T) {
 		err := service.Import(context.Background(), vdiID, payloads.VDIFormatVHD, content, int64(len(testContent)))
 
 		assert.NoError(t, err)
+	})
+}
+
+func TestCreate(t *testing.T) {
+	t.Run("successfully creates a VDI", func(t *testing.T) {
+		server, service, _ := setupTestServer(t)
+		defer server.Close()
+
+		params := payloads.VDICreateParams{
+			SRId:        uuid.Must(uuid.FromString(testSRID)),
+			VirtualSize: testVDIVirtualSize,
+			NameLabel:   testVDINameLabel1,
+		}
+
+		vdiID, err := service.Create(context.Background(), params)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, vdiID)
+	})
+
+	t.Run("returns error on http error", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		})
+		service, server, _ := setupTestServerWithHandler(t, handler)
+		defer server.Close()
+
+		params := payloads.VDICreateParams{
+			SRId:        uuid.Must(uuid.FromString(testSRID)),
+			VirtualSize: testVDIVirtualSize,
+			NameLabel:   testVDINameLabel1,
+		}
+
+		vdiID, err := service.Create(context.Background(), params)
+
+		assert.Error(t, err)
+		assert.Empty(t, vdiID)
+	})
+
+	t.Run("returns error on invalid json response", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte("invalid json"))
+			assert.NoError(t, err)
+		})
+		service, server, _ := setupTestServerWithHandler(t, handler)
+		defer server.Close()
+
+		params := payloads.VDICreateParams{
+			SRId:        uuid.Must(uuid.FromString(testSRID)),
+			VirtualSize: testVDIVirtualSize,
+			NameLabel:   testVDINameLabel1,
+		}
+
+		vdiID, err := service.Create(context.Background(), params)
+
+		assert.Error(t, err)
+		assert.Empty(t, vdiID)
 	})
 }

--- a/pkg/services/vdi/service_test.go
+++ b/pkg/services/vdi/service_test.go
@@ -23,22 +23,33 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const (
+	testVDIID1         = "c77f9955-c1d2-4b39-aa1c-73cdb2dacb7e"
+	testVDIID2         = "d88fa066-d2e3-5c4a-bc2d-84deb3eadcbf"
+	testVDIIDNotFound  = "e99fb177-e3f4-6d5b-cd3e-95efc4fbedc0"
+	testSRID           = "f2345678-1234-1234-1234-123456789abc"
+	testMigrateTaskID  = "task-migrate-123"
+	testVDINameLabel1  = "VDI 1"
+	testVDINameLabel2  = "VDI 2"
+	testVDIVirtualSize = int64(8589934592)
+)
+
 var mockVDIs = func() []*payloads.VDI {
 	return []*payloads.VDI{
 		{
 			UUID:            uuid.Must(uuid.FromString(testVDIID1)),
 			Type:            "VDI",
-			NameLabel:       "VDI 1",
+			NameLabel:       testVDINameLabel1,
 			NameDescription: "Test VDI 1",
 			VDIType:         "user",
 		},
 		{
 			UUID:            uuid.Must(uuid.FromString(testVDIID2)),
 			Type:            "VDI",
-			NameLabel:       "VDI 2",
+			NameLabel:       testVDINameLabel2,
 			NameDescription: "Test VDI 2",
 			VDIType:         "user",
-			Size:            8589934592,
+			Size:            testVDIVirtualSize,
 			Usage:           17152,
 		},
 	}
@@ -59,14 +70,6 @@ var mockTasks = func() []*payloads.Task {
 		},
 	}
 }
-
-const (
-	testVDIID1        = "c77f9955-c1d2-4b39-aa1c-73cdb2dacb7e"
-	testVDIID2        = "d88fa066-d2e3-5c4a-bc2d-84deb3eadcbf"
-	testVDIIDNotFound = "e99fb177-e3f4-6d5b-cd3e-95efc4fbedc0"
-	testSRID          = "f2345678-1234-1234-1234-123456789abc"
-	testMigrateTaskID = "task-migrate-123"
-)
 
 func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (*Service, *httptest.Server, *mock.MockTask) {
 	server := httptest.NewServer(handler)
@@ -433,8 +436,8 @@ func TestGetAll(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, vdis)
 		assert.Len(t, vdis, 2)
-		assert.Equal(t, "VDI 1", vdis[0].NameLabel)
-		assert.Equal(t, "VDI 2", vdis[1].NameLabel)
+		assert.Equal(t, testVDINameLabel1, vdis[0].NameLabel)
+		assert.Equal(t, testVDINameLabel2, vdis[1].NameLabel)
 	})
 }
 


### PR DESCRIPTION
This pr add the possibility to create "vdi" service with the v2 package. I also made a little refactor in order to use constants on my part