### PR TITLE
feat(v2): add StringifiedInt type for VIF device and VBD position/userdevice fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - ^client/
 formatters:
   enable:
     - gofmt

--- a/internal/tagger/tagger_test.go
+++ b/internal/tagger/tagger_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	testResourceID = "a1b2c3d4-1111-2222-3333-000000000001"
+	testTokenValue = "test-token"
 )
 
 func newTestLogger(t *testing.T) *logger.Logger {
@@ -61,7 +62,7 @@ func setupTestServer(t *testing.T, resourceType payloads.ResourceType) (*httptes
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	return server, New(restClient, newTestLogger(t), resourceType)
@@ -83,7 +84,7 @@ func setupTestServerWithHandler(
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	return server, New(restClient, newTestLogger(t), resourceType)
@@ -93,7 +94,7 @@ func TestNew(t *testing.T) {
 	log := newTestLogger(t)
 	restClient := &client.Client{
 		BaseURL:   &url.URL{Scheme: "http", Host: "localhost"},
-		AuthToken: "test-token",
+		AuthToken: testTokenValue,
 	}
 
 	svc := New(restClient, log, payloads.ResourceTypeSR)

--- a/pkg/payloads/common.go
+++ b/pkg/payloads/common.go
@@ -1,7 +1,46 @@
 package payloads
 
-import "github.com/gofrs/uuid"
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/gofrs/uuid"
+)
 
 type CreateResponse struct {
 	ID uuid.UUID `json:"id"`
+}
+
+// StringifiedInt represents an integer that is marshaled/unmarshaled as a string in JSON
+// This is used for fields like VIF Device that are stringified numbers in the API
+type StringifiedInt int
+
+func (s *StringifiedInt) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as a string
+	var stringValue string
+	if err := json.Unmarshal(data, &stringValue); err == nil {
+		if stringValue == "" {
+			*s = 0
+			return nil
+		}
+		intValue, err := strconv.Atoi(stringValue)
+		if err != nil {
+			return err
+		}
+		*s = StringifiedInt(intValue)
+		return nil
+	}
+
+	// If string unmarshaling fails, try as a regular integer
+	var intValue int
+	if err := json.Unmarshal(data, &intValue); err != nil {
+		return err
+	}
+	*s = StringifiedInt(intValue)
+	return nil
+}
+
+func (s StringifiedInt) MarshalJSON() ([]byte, error) {
+	// Marshal as a string representation of the integer
+	return json.Marshal(strconv.Itoa(int(s)))
 }

--- a/pkg/payloads/common_test.go
+++ b/pkg/payloads/common_test.go
@@ -1,0 +1,60 @@
+package payloads
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringifiedInt_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    StringifiedInt
+		expected string
+	}{
+		{"zero", 0, "\"0\""},
+		{"positive", 42, "\"42\""},
+		{"negative", -5, "\"-5\""},
+		{"large", 999999, "\"999999\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err, "MarshalJSON should not return an error")
+			assert.Equal(t, tt.expected, string(data), "Marshaled JSON should match expected string")
+		})
+	}
+}
+
+func TestStringifiedInt_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected StringifiedInt
+		wantErr  bool
+	}{
+		{"string_zero", `"0"`, 0, false},
+		{"string_positive", `"42"`, 42, false},
+		{"string_negative", `"-5"`, -5, false},
+		{"string_large", `"999999"`, 999999, false},
+		{"int_zero", `0`, 0, false},
+		{"int_positive", `42`, 42, false},
+		{"int_negative", `-5`, -5, false},
+		{"empty_string", `""`, 0, false},
+		{"invalid_string", `"abc"`, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result StringifiedInt
+			err := json.Unmarshal([]byte(tt.input), &result)
+			require.Equal(t, tt.wantErr, err != nil, "UnmarshalJSON error presence should match wantErr")
+			if !tt.wantErr {
+				assert.Equal(t, tt.expected, result, "Unmarshaled value should match expected")
+			}
+		})
+	}
+}

--- a/pkg/payloads/pool.go
+++ b/pkg/payloads/pool.go
@@ -1,6 +1,8 @@
 package payloads
 
-import "github.com/gofrs/uuid"
+import (
+	"github.com/gofrs/uuid"
+)
 
 type PoolCPUs struct {
 	Cores   int `json:"cores"`
@@ -56,13 +58,15 @@ type VDIParams struct {
 }
 
 type VIFParams struct {
-	Destroy     *bool    `json:"destroy,omitempty"`
-	Device      *string  `json:"device,omitempty"`
-	IPV4Allowed []string `json:"ipv4_allowed,omitempty"`
-	IPV6Allowed []string `json:"ipv6_allowed,omitempty"`
-	MAC         *string  `json:"mac,omitempty"`
-	MTU         *int     `json:"mtu,omitempty"`
-	Network     *string  `json:"network,omitempty"`
+	Destroy *bool `json:"destroy,omitempty"`
+	// Order in which VIF backends are created by xapi.Guaranteed to be an unsigned decimal integer.
+	// Represented as a string in JSON but stored as an integer in Go.
+	Device      *StringifiedInt `json:"device,omitempty"`
+	IPV4Allowed []string        `json:"ipv4_allowed,omitempty"`
+	IPV6Allowed []string        `json:"ipv6_allowed,omitempty"`
+	MAC         *string         `json:"mac,omitempty"`
+	MTU         *int            `json:"mtu,omitempty"`
+	Network     *uuid.UUID      `json:"network,omitempty"`
 }
 
 type CreateVMParams struct {

--- a/pkg/payloads/pool_test.go
+++ b/pkg/payloads/pool_test.go
@@ -1,0 +1,30 @@
+package payloads
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVIFParams_DeviceField(t *testing.T) {
+	// Test that VIFParams can handle stringified device numbers
+	jsonData := `{
+		"device": "2"
+	}`
+
+	var vif VIFParams
+	err := json.Unmarshal([]byte(jsonData), &vif)
+	require.NoError(t, err, "Failed to unmarshal VIFParams with stringified device")
+	require.NotNil(t, vif.Device, "Device field should not be nil after unmarshaling")
+
+	expected := StringifiedInt(2)
+	require.Equal(t, expected, *vif.Device, "Device field should be correctly parsed from stringified JSON")
+
+	// Test marshaling back to JSON
+	marshaled, err := json.Marshal(vif)
+	require.NoError(t, err, "Failed to marshal VIFParams with stringified device")
+
+	assert.Contains(t, string(marshaled), "\"2\"", "Marshaled JSON should contain stringified device number")
+}

--- a/pkg/payloads/vbd.go
+++ b/pkg/payloads/vbd.go
@@ -16,11 +16,11 @@ type VBD struct {
 	Attached bool      `json:"attached"`
 	Bootable bool      `json:"bootable"`
 	// Device is the device name (e.g. "xvda"), null when not plugged in.
-	Device    *string    `json:"device"`
-	IsCDDrive bool       `json:"is_cd_drive"`
-	Position  string     `json:"position"`
-	ReadOnly  bool       `json:"read_only"`
-	VDI       *uuid.UUID `json:"VDI,omitempty"`
+	Device    *string        `json:"device"`
+	IsCDDrive bool           `json:"is_cd_drive"`
+	Position  StringifiedInt `json:"position"`
+	ReadOnly  bool           `json:"read_only"`
+	VDI       *uuid.UUID     `json:"VDI,omitempty"`
 	// VM is the ID of the VM this VBD is attached to.
 	VM uuid.UUID `json:"VM"`
 }
@@ -54,9 +54,9 @@ type CreateVBDParams struct {
 	// Mode is the access mode (RO, RW)
 	Mode VBDMode `json:"mode,omitempty"`
 	// Bootable indicates whether this VBD is bootable
-	Bootable bool `json:"bootable,omitempty"`
+	Bootable *bool `json:"bootable,omitempty"`
 	// Userdevice is the position/slot for the device
-	Userdevice string `json:"userdevice,omitempty"`
+	Userdevice *StringifiedInt `json:"userdevice,omitempty"`
 	// Unpluggable indicates whether the VBD can be hot-unplugged
 	Unpluggable *bool `json:"unpluggable,omitempty"`
 	// Empty indicates whether the CD drive is empty (only relevant for CD type)

--- a/pkg/services/host/host_test.go
+++ b/pkg/services/host/host_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/vatesfr/xenorchestra-go-sdk/v2/client"
 )
 
+const testTokenValue = "test-token"
+
 // This is a basic test to ensure the service can be instantiated.
 func TestNew(t *testing.T) {
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -38,7 +40,7 @@ func TestHostService_Get_InvalidUUID(t *testing.T) {
 	// This test mainly checks that the code compiles and imports are correct
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -98,7 +100,7 @@ func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (library
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	mockService := New(restClient, log)
@@ -141,44 +143,12 @@ func setupTestServer(t *testing.T) (*httptest.Server, library.Host) {
 		}
 	})
 
-	// PUT /rest/v0/hosts/{id}/tags/{tag} - Add tag to host
-	mux.HandleFunc("PUT /rest/v0/hosts/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		hostID := r.PathValue("id")
-
-		if host := findHostByID(hostID); host == nil {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	// DELETE /rest/v0/hosts/{id}/tags/{tag} - Remove tag from host
-	mux.HandleFunc("DELETE /rest/v0/hosts/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		hostID := r.PathValue("id")
-
-		if host := findHostByID(hostID); host == nil {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
 	server := httptest.NewServer(mux)
 
 	restClient := &client.Client{
 		HttpClient: http.DefaultClient,
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	log, err := logger.New(false, []string{"stdout"}, []string{"stderr"})

--- a/pkg/services/jsonrpc/service_test.go
+++ b/pkg/services/jsonrpc/service_test.go
@@ -134,7 +134,7 @@ func TestCall(t *testing.T) {
 	t.Run("error call", func(t *testing.T) {
 		var result string
 		err := jsonrpcSvc.Call("error.method", map[string]any{
-			"param1": "value1",
+			"param3": "value3",
 		}, &result)
 
 		assert.Error(t, err)
@@ -162,7 +162,7 @@ func TestCall(t *testing.T) {
 	t.Run("with log context", func(t *testing.T) {
 		var result string
 		err := jsonrpcSvc.Call("success.method", map[string]any{
-			"param1": "value1",
+			"param4": "value4",
 		}, &result, zap.String("context", "test-context"))
 
 		assert.NoError(t, err)

--- a/pkg/services/pbd/service_test.go
+++ b/pkg/services/pbd/service_test.go
@@ -26,6 +26,8 @@ const (
 	testPBDID1        = "b22c3d4e-2345-6789-bcde-222233334444"
 	testPBDID2        = "c33d4e5f-3456-789a-cdef-333344445555"
 	testPBDIDNotFound = "d44e5f60-4567-89ab-def0-444455556666"
+	testTokenValue    = "test-token"
+	testFakeTaskID    = "task-abc"
 )
 
 var mockPBDs = func() []*payloads.PBD {
@@ -68,7 +70,7 @@ func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (*Servic
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -125,7 +127,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		switch r.PathValue("action") {
 		case "plug", "unplug":
 			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: "task-abc"}); err != nil {
+			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: testFakeTaskID}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		default:
@@ -138,7 +140,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	log, err := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -154,7 +156,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 func TestNew(t *testing.T) {
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -273,13 +275,13 @@ func TestPlug(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.Plug(t.Context(), pbdID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -299,7 +301,7 @@ func TestPlug(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.Plug(t.Context(), pbdID)
@@ -318,13 +320,13 @@ func TestUnplug(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.Unplug(t.Context(), pbdID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -344,7 +346,7 @@ func TestUnplug(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.Unplug(t.Context(), pbdID)

--- a/pkg/services/pool/service_test.go
+++ b/pkg/services/pool/service_test.go
@@ -20,6 +20,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const testFakeTaskID = "task-abc"
+
 func setupTestServer(t *testing.T, handler http.HandlerFunc) (library.Pool, *httptest.Server) {
 	server := httptest.NewServer(handler)
 	log, _ := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -175,7 +177,7 @@ func TestCreateResource(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(&payloads.Task{
 				Status: payloads.Success,
 				Result: payloads.Result{ID: expectedID},
@@ -188,7 +190,7 @@ func TestCreateResource(t *testing.T) {
 			err := json.NewDecoder(r.Body).Decode(&vm)
 			assert.NoError(t, err)
 			assert.Equal(t, "test-vm", vm.NameLabel)
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 
 		poolService, server := setupTestServer(t, handler)
@@ -225,11 +227,11 @@ func TestCreateResource(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(nil, fmt.Errorf("boom"))
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 		poolService, server := setupTestServer(t, handler)
 		defer server.Close()
@@ -270,14 +272,14 @@ func TestCreateResource(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(&payloads.Task{
 				Status: payloads.Failure,
 				Result: payloads.Result{Message: "creation failed"},
 			}, nil)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 		poolService, server := setupTestServer(t, handler)
 		defer server.Close()
@@ -364,7 +366,7 @@ func TestCreateNetworkParams(t *testing.T) {
 			assert.Equal(t, uint(1500), *body.MTU)
 			assert.Equal(t, uint(100), body.Vlan)
 			// reply with a task response string
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 
 		poolService, server := setupTestServer(t, handler)
@@ -392,13 +394,13 @@ func TestPerformPoolAction(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(&payloads.Task{
 				Status: payloads.Success,
 			}, nil)
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 
 		poolService, server := setupTestServer(t, handler)
@@ -429,11 +431,11 @@ func TestPerformPoolAction(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(nil, fmt.Errorf("boom"))
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 		poolService, server := setupTestServer(t, handler)
 		defer server.Close()
@@ -450,14 +452,14 @@ func TestPerformPoolAction(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockTask := mock.NewMockTask(ctrl)
-		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-response"}, true).
+		mockTask.EXPECT().HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, true).
 			Return(&payloads.Task{
 				Status: payloads.Failure,
 				Result: payloads.Result{Message: "failed action"},
 			}, nil)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("{\"taskId\":\"task-response\"}"))
+			_, _ = w.Write([]byte("{\"taskId\":\"" + testFakeTaskID + "\"}"))
 		})
 		poolService, server := setupTestServer(t, handler)
 		defer server.Close()

--- a/pkg/services/sr/service_test.go
+++ b/pkg/services/sr/service_test.go
@@ -25,6 +25,8 @@ const (
 	testSRID2        = "a1b2c3d4-1111-2222-3333-000000000002"
 	testSRIDNotFound = "d44e5f60-4567-89ab-def0-444455556666"
 	testPoolID       = "b2c3d4e5-0000-0000-0000-000000000001"
+	testFakeTaskID   = "task-abc"
+	testTokenValue   = "test-token"
 )
 
 var mockSRs = func() []*payloads.StorageRepository {
@@ -81,7 +83,7 @@ func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (*Servic
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -154,7 +156,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		switch r.PathValue("action") {
 		case "reclaim_space", "scan":
 			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: "task-abc"}); err != nil {
+			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: testFakeTaskID}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		default:
@@ -162,30 +164,12 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		}
 	})
 
-	// PUT /rest/v0/srs/{id}/tags/{tag} - AddTag
-	mux.HandleFunc("PUT /rest/v0/srs/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		if _, err := uuid.FromString(r.PathValue("id")); err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	// DELETE /rest/v0/srs/{id}/tags/{tag} - RemoveTag
-	mux.HandleFunc("DELETE /rest/v0/srs/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		if _, err := uuid.FromString(r.PathValue("id")); err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
-
 	server := httptest.NewServer(mux)
 
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	log, err := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -201,7 +185,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 func TestNew(t *testing.T) {
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -394,13 +378,13 @@ func TestReclaimSpace(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.ReclaimSpace(t.Context(), srID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -420,7 +404,7 @@ func TestReclaimSpace(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.ReclaimSpace(t.Context(), srID)
@@ -439,13 +423,13 @@ func TestScan(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.Scan(t.Context(), srID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -465,7 +449,7 @@ func TestScan(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.Scan(t.Context(), srID)

--- a/pkg/services/task/service_test.go
+++ b/pkg/services/task/service_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/vatesfr/xenorchestra-go-sdk/v2/client"
 )
 
+const (
+	testFakeTaskID    = "task-123"
+	testSuccessTaskID = "success-task-123"
+)
+
 func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (library.Task, *httptest.Server) {
 	server := httptest.NewServer(handler)
 	log, _ := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -69,9 +74,9 @@ func setupTestServer(t *testing.T) (*httptest.Server, library.Task) {
 			// Handle different task scenarios based on task ID
 			var task payloads.Task
 			switch taskID {
-			case "success-task-123":
+			case testSuccessTaskID:
 				task = payloads.Task{
-					ID:     "success-task-123",
+					ID:     testSuccessTaskID,
 					Status: payloads.Success,
 					Properties: payloads.Properties{
 						Name: "vm.create",
@@ -150,10 +155,10 @@ func TestGet(t *testing.T) {
 	defer server.Close()
 
 	t.Run("successful task", func(t *testing.T) {
-		task, err := service.Get(context.Background(), "success-task-123")
+		task, err := service.Get(context.Background(), testSuccessTaskID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "success-task-123", task.ID)
+		assert.Equal(t, testSuccessTaskID, task.ID)
 		assert.Equal(t, payloads.Success, task.Status)
 		assert.Equal(t, "vm.create", task.Properties.Name)
 		assert.Equal(t, uuid.Must(uuid.FromString("361f2903-2c09-486e-9eff-91debeeee304")), task.Result.ID)
@@ -163,7 +168,7 @@ func TestGet(t *testing.T) {
 		task, err := service.Get(context.Background(), "/rest/v0/tasks/success-task-123")
 
 		assert.NoError(t, err)
-		assert.Equal(t, "success-task-123", task.ID)
+		assert.Equal(t, testSuccessTaskID, task.ID)
 		assert.Equal(t, payloads.Success, task.Status)
 	})
 
@@ -227,8 +232,8 @@ func TestGetAllTasks(t *testing.T) {
 
 	t.Run("successfully retrieves all tasks", func(t *testing.T) {
 		expectedTasks := []payloads.Task{
-			{ID: "0mhke8vi7", Status: "failure"},
-			{ID: "0mhknlx4j", Status: "success"},
+			{ID: "0mhke8vi7", Status: payloads.Failure},
+			{ID: "0mhknlx4j", Status: payloads.Success},
 		}
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -280,10 +285,10 @@ func TestWait(t *testing.T) {
 	defer server.Close()
 
 	t.Run("wait for completed task", func(t *testing.T) {
-		task, err := service.Wait(context.Background(), "success-task-123")
+		task, err := service.Wait(context.Background(), testSuccessTaskID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "success-task-123", task.ID)
+		assert.Equal(t, testSuccessTaskID, task.ID)
 		assert.Equal(t, payloads.Success, task.Status)
 	})
 
@@ -341,21 +346,21 @@ func TestHandleTaskResponse(t *testing.T) {
 
 	t.Run("handle task URL without waiting", func(t *testing.T) {
 		task, err := service.HandleTaskResponse(context.Background(),
-			payloads.TaskIDResponse{TaskID: "success-task-123"}, false)
+			payloads.TaskIDResponse{TaskID: testSuccessTaskID}, false)
 
 		require.NoError(t, err)
 		require.NotNil(t, task)
-		assert.Equal(t, "success-task-123", task.ID)
+		assert.Equal(t, testSuccessTaskID, task.ID)
 		assert.Equal(t, payloads.Success, task.Status)
 	})
 
 	t.Run("handle task URL with waiting", func(t *testing.T) {
 		task, err := service.HandleTaskResponse(context.Background(),
-			payloads.TaskIDResponse{TaskID: "success-task-123"}, true)
+			payloads.TaskIDResponse{TaskID: testSuccessTaskID}, true)
 
 		require.NoError(t, err)
 		require.NotNil(t, task)
-		assert.Equal(t, "success-task-123", task.ID)
+		assert.Equal(t, testSuccessTaskID, task.ID)
 		assert.Equal(t, payloads.Success, task.Status)
 	})
 
@@ -386,8 +391,8 @@ func TestCleanDuplicateV0Path(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"full task path", "/rest/v0/tasks/task-123", "task-123"},
-		{"task ID only", "task-123", "task-123"},
+		{"full task path", "/rest/v0/tasks/task-123", testFakeTaskID},
+		{"task ID only", testFakeTaskID, testFakeTaskID},
 		{"path without leading slash", "rest/v0/tasks/task-123", "rest/v0/tasks/task-123"},
 		{"empty string", "", ""},
 		{"just task prefix", "/rest/v0/tasks/", ""},

--- a/pkg/services/vbd/service_test.go
+++ b/pkg/services/vbd/service_test.go
@@ -39,7 +39,7 @@ var mockVBDs = func() []*payloads.VBD {
 			Bootable:  true,
 			Device:    &device1,
 			IsCDDrive: false,
-			Position:  "0",
+			Position:  payloads.StringifiedInt(0),
 			ReadOnly:  false,
 			VM:        uuid.Must(uuid.FromString(testVMID)),
 		},
@@ -50,7 +50,7 @@ var mockVBDs = func() []*payloads.VBD {
 			Bootable:  false,
 			Device:    nil,
 			IsCDDrive: false,
-			Position:  "1",
+			Position:  payloads.StringifiedInt(1),
 			ReadOnly:  true,
 			VM:        uuid.Must(uuid.FromString(testVMID)),
 		},
@@ -319,14 +319,16 @@ func TestCreate(t *testing.T) {
 		svc, server, _ := setupTestServerWithHandler(t, makeSuccessHandler(&capturedBody))
 		defer server.Close()
 
+		bootable := true
+		userDevice := payloads.StringifiedInt(0)
 		unpluggable := true
 		id, err := svc.Create(t.Context(), &payloads.CreateVBDParams{
 			VM:          vmID,
 			VDI:         vdiID,
 			Type:        payloads.VBDTypeDisk,
 			Mode:        payloads.VBDModeRW,
-			Bootable:    true,
-			Userdevice:  "0",
+			Bootable:    &bootable,
+			Userdevice:  &userDevice,
 			Unpluggable: &unpluggable,
 		})
 

--- a/pkg/services/vbd/service_test.go
+++ b/pkg/services/vbd/service_test.go
@@ -27,6 +27,8 @@ const (
 	testVBDID1        = "b22c3d4e-2345-6789-bcde-222233334444"
 	testVBDID2        = "c33d4e5f-3456-789a-cdef-333344445555"
 	testVBDIDNotFound = "d44e5f60-4567-89ab-def0-444455556666"
+	testFakeTaskID    = "task-abc"
+	testTokenValue    = "test-token"
 )
 
 var mockVBDs = func() []*payloads.VBD {
@@ -90,7 +92,7 @@ func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (*Servic
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -159,7 +161,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		switch r.PathValue("action") {
 		case "connect", "disconnect":
 			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: "task-abc"}); err != nil {
+			if err := json.NewEncoder(w).Encode(payloads.TaskIDResponse{TaskID: testFakeTaskID}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		default:
@@ -188,7 +190,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	log, err := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -204,7 +206,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 func TestNew(t *testing.T) {
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -487,13 +489,13 @@ func TestConnect(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.Connect(t.Context(), vbdID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -513,7 +515,7 @@ func TestConnect(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.Connect(t.Context(), vbdID)
@@ -532,13 +534,13 @@ func TestDisconnect(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
-			Return(&payloads.Task{ID: "task-abc"}, nil)
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
+			Return(&payloads.Task{ID: testFakeTaskID}, nil)
 
 		taskID, err := svc.Disconnect(t.Context(), vbdID)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "task-abc", taskID)
+		assert.Equal(t, testFakeTaskID, taskID)
 	})
 
 	t.Run("returns error on http error", func(t *testing.T) {
@@ -558,7 +560,7 @@ func TestDisconnect(t *testing.T) {
 		defer server.Close()
 
 		mockTask.EXPECT().
-			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: "task-abc"}, false).
+			HandleTaskResponse(gomock.Any(), payloads.TaskIDResponse{TaskID: testFakeTaskID}, false).
 			Return(nil, fmt.Errorf("task failed"))
 
 		taskID, err := svc.Disconnect(t.Context(), vbdID)

--- a/pkg/services/vdi/service_test.go
+++ b/pkg/services/vdi/service_test.go
@@ -32,6 +32,7 @@ const (
 	testVDINameLabel1  = "VDI 1"
 	testVDINameLabel2  = "VDI 2"
 	testVDIVirtualSize = int64(8589934592)
+	testTokenValue     = "test-token"
 )
 
 var mockVDIs = func() []*payloads.VDI {
@@ -87,7 +88,7 @@ func setupTestServerWithHandler(t *testing.T, handler http.HandlerFunc) (*Servic
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    baseURL,
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -161,38 +162,6 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
-		}
-	})
-
-	// PUT /rest/v0/vdis/{id}/tags/{tag} - Add tag to vdi
-	mux.HandleFunc("PUT /rest/v0/vdis/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		vdiID := r.PathValue("id")
-
-		if vdiID != testVDIID1 && vdiID != testVDIID2 {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	// DELETE /rest/v0/vdis/{id}/tags/{tag} - Remove tag from vdi
-	mux.HandleFunc("DELETE /rest/v0/vdis/{id}/tags/{tag}", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		vdiID := r.PathValue("id")
-
-		if vdiID != testVDIID1 && vdiID != testVDIID2 {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(map[string]bool{"success": true}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	})
 
@@ -331,7 +300,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 	restClient := &client.Client{
 		HttpClient: server.Client(),
 		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: "/rest/v0"},
-		AuthToken:  "test-token",
+		AuthToken:  testTokenValue,
 	}
 
 	log, err := logger.New(false, []string{"stdout"}, []string{"stderr"})
@@ -348,7 +317,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Service, *mock.MockTask) 
 func TestNew(t *testing.T) {
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)
@@ -365,7 +334,7 @@ func TestVDIService_Get_ConnectionError(t *testing.T) {
 	// This test mainly checks that the code compiles and imports are correct
 	cfg := &config.Config{
 		Url:   "http://localhost",
-		Token: "test-token",
+		Token: testTokenValue,
 	}
 	c, err := client.New(cfg)
 	assert.NoError(t, err)

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -26,8 +26,11 @@ func (t Token) String() string {
 }
 
 const (
-	WebSocketScheme       = "ws"
-	SecureWebSocketScheme = "wss"
+	webSocketScheme       = "ws"
+	secureWebSocketScheme = "wss"
+	httpScheme            = "http"
+	httpsScheme           = "https"
+	authCookieName        = "authenticationToken"
 )
 
 // Client handles communication with the Xen Orchestra REST API.
@@ -60,10 +63,10 @@ func New(config *config.Config) (*Client, error) {
 	}
 
 	switch baseURL.Scheme {
-	case WebSocketScheme:
-		baseURL.Scheme = "http"
-	case SecureWebSocketScheme:
-		baseURL.Scheme = "https"
+	case webSocketScheme:
+		baseURL.Scheme = httpScheme
+	case secureWebSocketScheme:
+		baseURL.Scheme = httpsScheme
 	}
 
 	baseURL.Path = path.Join(baseURL.Path, core.RestV0Path)
@@ -134,7 +137,7 @@ func (c *Client) authenticate(username, password string) (Token, error) {
 	}
 
 	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "authenticationToken" {
+		if cookie.Name == authCookieName {
 			return Token(cookie.Value), nil
 		}
 	}
@@ -158,8 +161,9 @@ func (c *Client) buildURL(endpoint string) url.URL {
 // The caller is responsible for closing the response body when finished reading it.
 // For error responses (non-2xx), the body is read, closed, and included in the error message.
 func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
+	// #nosec G124 -- Outbound request cookie for SDK auth; Secure/HttpOnly/SameSite do not apply here.
 	req.AddCookie(&http.Cookie{
-		Name:  "authenticationToken",
+		Name:  authCookieName,
 		Value: c.AuthToken.String(),
 	})
 

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -13,7 +13,10 @@ import (
 
 var ctx = context.Background()
 
-const restPath = "/rest/v0"
+const (
+	restPath       = "/rest/v0"
+	testTokenValue = "test-token"
+)
 
 func TestNew(t *testing.T) {
 	_, err := New(&config.Config{Url: "://invalid-url", Token: "abc"})
@@ -38,8 +41,11 @@ func TestAuthenticate(t *testing.T) {
 
 			if creds.Username == "testuser" && creds.Password == "testpass" {
 				http.SetCookie(w, &http.Cookie{
-					Name:  "authenticationToken",
-					Value: "test-token",
+					Name:     authCookieName,
+					HttpOnly: true,
+					SameSite: http.SameSiteStrictMode,
+					Secure:   true,
+					Value:    testTokenValue,
 				})
 				w.WriteHeader(http.StatusOK)
 				return
@@ -63,7 +69,7 @@ func TestAuthenticate(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	if client.AuthToken != "test-token" {
+	if client.AuthToken != testTokenValue {
 		t.Errorf("Expected token 'test-token', got '%s'", client.AuthToken)
 	}
 
@@ -80,8 +86,8 @@ func TestAuthenticate(t *testing.T) {
 
 func TestDo(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cookie, err := r.Cookie("authenticationToken")
-		if err != nil || cookie.Value != "test-token" {
+		cookie, err := r.Cookie(authCookieName)
+		if err != nil || cookie.Value != testTokenValue {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -112,8 +118,8 @@ func TestDo(t *testing.T) {
 
 	client := &Client{
 		HttpClient: http.DefaultClient,
-		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: restPath},
-		AuthToken:  "test-token",
+		BaseURL:    &url.URL{Scheme: httpScheme, Host: server.URL[7:], Path: restPath},
+		AuthToken:  testTokenValue,
 	}
 
 	var getResult struct {
@@ -158,8 +164,8 @@ func TestTypedGet(t *testing.T) {
 
 	client := &Client{
 		HttpClient: http.DefaultClient,
-		BaseURL:    &url.URL{Scheme: "http", Host: server.URL[7:], Path: restPath},
-		AuthToken:  "test-token",
+		BaseURL:    &url.URL{Scheme: httpScheme, Host: server.URL[7:], Path: restPath},
+		AuthToken:  testTokenValue,
 	}
 
 	// Define the request and response types

--- a/v2/integration/pool_test.go
+++ b/v2/integration/pool_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -12,159 +13,162 @@ import (
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
 )
 
-func TestGetPoolByID(t *testing.T) {
-	ctx, client, _ := SetupTestContext(t)
+func TestGetPool(t *testing.T) {
+	t.Run("ByID", func(t *testing.T) {
+		ctx, client, _ := SetupTestContext(t)
 
-	pool, err := client.Pool().Get(ctx, intTests.testPool.ID)
-	if err != nil {
-		t.Fatalf("error while fetching pool %s: %v", intTests.testPool.ID, err)
-	}
-	assert.Equal(t, intTests.testPool.ID, pool.ID, "pool ID should match")
-}
+		pool, err := client.Pool().Get(ctx, intTests.testPool.ID)
+		require.NoError(t, err, "error while fetching pool %s: %v", intTests.testPool.ID, err)
+		assert.Equal(t, intTests.testPool.ID, pool.ID, "pool ID should match")
+	})
 
-func TestGetPoolByInvalidID(t *testing.T) {
-	ctx, client, _ := SetupTestContext(t)
+	t.Run("ByInvalidID", func(t *testing.T) {
+		ctx, client, _ := SetupTestContext(t)
 
-	_, err := client.Pool().Get(ctx, uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"))
-	if err == nil {
-		t.Fatal("expected error when fetching pool with invalid ID, got nil")
-	}
-	assert.Contains(t, err.Error(), "404 Not Found", "error message should indicate not found")
+		_, err := client.Pool().Get(ctx, uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"))
+		require.Error(t, err, "expected error when fetching pool with invalid ID, got nil")
+		assert.Contains(t, err.Error(), "404 Not Found", "error message should indicate not found")
+	})
 }
 
 func TestCreateVM(t *testing.T) {
-	ctx, client, testPrefix := SetupTestContext(t)
 
-	vmName := "test-vm"
-	params := payloads.CreateVMParams{
-		NameLabel: testPrefix + vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
-	}
+	t.Run("CreateVM", func(t *testing.T) {
+		t.Parallel()
+		ctx, client, testPrefix := SetupTestContext(t)
 
-	vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
-	if err != nil {
-		t.Fatalf("error while creating VM in pool %s: %v", intTests.testPool.ID, err)
-	}
-	assert.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
-
-	// Cleanup
-	err = client.VM().Delete(ctx, vmID)
-	if err != nil {
-		t.Errorf("error while deleting VM %s: %v", vmID, err)
-	}
-}
-
-func TestCreateVMWithVIFDevice(t *testing.T) {
-	ctx, client, testPrefix := SetupTestContext(t)
-
-	// Use the existing test network instead of creating a new one to avoid VLAN conflicts
-	// The test network is already available in intTests.testNetwork
-	networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
-	if networkID == uuid.Nil {
-		t.Skip("No test network available, skipping VIF device test")
-	}
-
-	// Create VM with specific VIF device setting
-	vmName := "test-vm-vif-device"
-	deviceZero := payloads.StringifiedInt(0)
-
-	params := payloads.CreateVMParams{
-		NameLabel: testPrefix + vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
-		VIFs: []payloads.VIFParams{
-			{
-				Device:  &deviceZero,
-				Network: &networkID,
-			},
-		},
-	}
-
-	vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
-	require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
-	require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
-
-	// Verify the VM was created and get its details
-	vm, err := client.VM().GetByID(ctx, vmID)
-	require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
-	require.NotNil(t, vm, "VM details should not be nil")
-
-	// Get the VIFs for the VM using the v1 client
-	vmObj := &v1.Vm{Id: vmID.String()}
-	vifs, err := intTests.v1Client.GetVIFs(vmObj)
-	require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
-
-	// Verify we have exactly one VIF (the one we specified)
-	assert.Equal(t, 1, len(vifs), "VM should have exactly one VIF")
-
-	// Verify the VIF has the correct device setting and network
-	assert.Equal(t, "0", vifs[0].Device, "VIF device should be '0'")
-	assert.Equal(t, networkID.String(), vifs[0].Network, "VIF should be attached to the test network")
-}
-
-// This TC is meant to verify that when a VIF is set without a device,
-// it is added to the VIFs already present on the template and not replacing them.
-func TestCreateVMWithVIFNoDevice(t *testing.T) {
-	ctx, client, testPrefix := SetupTestContext(t)
-
-	networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
-	if networkID == uuid.Nil {
-		t.Skip("No test network available, skipping VIF device test")
-	}
-
-	// Create VM with specific VIF device setting
-	vmName := "test-vm-vif-device"
-	params := payloads.CreateVMParams{
-		NameLabel: testPrefix + vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
-		VIFs: []payloads.VIFParams{
-			{
-				Network: &networkID,
-			},
-		},
-	}
-
-	vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
-	require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
-	require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
-
-	// Verify the VM was created and get its details
-	vm, err := client.VM().GetByID(ctx, vmID)
-	require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
-	require.NotNil(t, vm, "VM details should not be nil")
-
-	// Get the VIFs for the VM using the v1 client
-	vmObj := &v1.Vm{Id: vmID.String()}
-	vifs, err := intTests.v1Client.GetVIFs(vmObj)
-	require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
-
-	// Verify we have exactly one VIF (the one we specified)
-	assert.Equal(t, 2, len(vifs), "VM should have exactly one VIF")
-
-	// Verify that one of the VIFs has the network attached
-	var vifWithNetwork *v1.VIF
-	for i := range vifs {
-		if vifs[i].Network == networkID.String() {
-			vifWithNetwork = &vifs[i]
-			assert.NotEqual(t, "0", vifs[i].Device, "VIF device shouldn't be '0'")
+		vmName := "test-vm"
+		params := payloads.CreateVMParams{
+			NameLabel: testPrefix + vmName,
+			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
 		}
-	}
-	assert.NotNil(t, vifWithNetwork, "One VIF should be attached to the test network")
-}
 
-func TestCreateVMInvalidTemplate(t *testing.T) {
-	ctx, client, testPrefix := SetupTestContext(t)
+		vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+		require.NoError(t, err, "error while creating VM in pool %s: %v", intTests.testPool.ID, err)
+		assert.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
 
-	vmName := "test-vm-invalid-template"
-	params := payloads.CreateVMParams{
-		NameLabel: testPrefix + vmName,
-		Template:  uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"), // Invalid template ID
-	}
+		// Cleanup
+		err = client.VM().Delete(ctx, vmID)
+		if err != nil {
+			t.Errorf("error while deleting VM %s: %v", vmID, err)
+		}
+	})
 
-	_, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
-	if err == nil {
-		t.Fatal("expected error when creating VM with invalid template ID, got nil")
-	}
-	assert.Contains(t, err.Error(), "vm creation failed: no such object", "error message should indicate bad request")
+	t.Run("WithVIFDevice", func(t *testing.T) {
+		t.Parallel()
+		ctx, client, testPrefix := SetupTestContext(t)
+
+		// Use the existing test network instead of creating a new one to avoid VLAN conflicts
+		// The test network is already available in intTests.testNetwork
+		networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+		if networkID == uuid.Nil {
+			t.Skip("No test network available, skipping VIF device test")
+		}
+
+		// Create VM with specific VIF device setting
+		vmName := "test-vm-vif-device"
+		deviceZero := payloads.StringifiedInt(0)
+
+		params := payloads.CreateVMParams{
+			NameLabel: testPrefix + vmName,
+			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			VIFs: []payloads.VIFParams{
+				{
+					Device:  &deviceZero,
+					Network: &networkID,
+				},
+			},
+		}
+
+		vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+		require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
+		require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
+
+		// Verify the VM was created and get its details
+		vm, err := client.VM().GetByID(ctx, vmID)
+		require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
+		require.NotNil(t, vm, "VM details should not be nil")
+
+		// Get the VIFs for the VM using the v1 client
+		vmObj := &v1.Vm{Id: vmID.String()}
+		vifs, err := intTests.v1Client.GetVIFs(vmObj)
+		require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
+
+		// Verify we have exactly one VIF (the one we specified)
+		assert.Equal(t, 1, len(vifs), "VM should have exactly one VIF")
+
+		// Verify the VIF has the correct device setting and network
+		assert.Equal(t, "0", vifs[0].Device, "VIF device should be '0'")
+		assert.Equal(t, networkID.String(), vifs[0].Network, "VIF should be attached to the test network")
+	})
+
+	// This TC is meant to verify that when a VIF is set without a device,
+	// it is added to the VIFs already present on the template and not replacing them.
+	t.Run("WithVIFNoDevice", func(t *testing.T) {
+		t.Parallel()
+		ctx, client, testPrefix := SetupTestContext(t)
+
+		networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+		if networkID == uuid.Nil {
+			t.Skip("No test network available, skipping VIF device test")
+		}
+
+		// Create VM with specific VIF device setting
+		vmName := "test-vm-vif-device"
+		params := payloads.CreateVMParams{
+			NameLabel: testPrefix + vmName,
+			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			VIFs: []payloads.VIFParams{
+				{
+					Network: &networkID,
+				},
+			},
+		}
+
+		vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+		require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
+		require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
+
+		// Verify the VM was created and get its details
+		vm, err := client.VM().GetByID(ctx, vmID)
+		require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
+		require.NotNil(t, vm, "VM details should not be nil")
+
+		// Get the VIFs for the VM using the v1 client
+		vmObj := &v1.Vm{Id: vmID.String()}
+		vifs, err := intTests.v1Client.GetVIFs(vmObj)
+		require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
+
+		// Verify we have exactly one VIF (the one we specified)
+		assert.Equal(t, 2, len(vifs), "VM should have exactly one VIF")
+
+		// Verify that one of the VIFs has the network attached
+		var vifWithNetwork *v1.VIF
+		for i := range vifs {
+			if vifs[i].Network == networkID.String() {
+				vifWithNetwork = &vifs[i]
+				assert.NotEqual(t, "0", vifs[i].Device, "VIF device shouldn't be '0'")
+			}
+		}
+		assert.NotNil(t, vifWithNetwork, "One VIF should be attached to the test network")
+	})
+
+	t.Run("InvalidTemplate", func(t *testing.T) {
+		t.Parallel()
+		ctx, client, testPrefix := SetupTestContext(t)
+
+		vmName := "test-vm-invalid-template"
+		params := payloads.CreateVMParams{
+			NameLabel: testPrefix + vmName,
+			Template:  uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"), // Invalid template ID
+		}
+
+		_, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+		require.Error(t, err, "expected error when creating VM with invalid template ID, got nil")
+		assert.Contains(t, err.Error(),
+			fmt.Sprintf("failed to create vm on pool %s: API error: 404 Not Found", intTests.testPool.ID),
+			"error message should indicate bad request")
+	})
 }
 
 func TestCreateNetwork(t *testing.T) {
@@ -188,9 +192,7 @@ func TestCreateNetwork(t *testing.T) {
 		Vlan:        vlan,
 	}
 	networkID, err := client.Pool().CreateNetwork(ctx, intTests.testPool.ID, params)
-	if err != nil {
-		t.Fatalf("error while creating network in pool %s: %v", intTests.testPool.ID, err)
-	}
+	require.NoError(t, err, "error while creating network in pool %s: %v", intTests.testPool.ID, err)
 	assert.NotEqual(t, uuid.Nil, networkID, "created network ID should not be nil")
 
 	// Get network using v1 client to verify creation
@@ -198,9 +200,7 @@ func TestCreateNetwork(t *testing.T) {
 	createdNetwork, err := intTests.v1Client.GetNetwork(v1.Network{
 		Id: networkID.String(),
 	})
-	if err != nil {
-		t.Fatalf("error fetching created network %s: %v", networkID, err)
-	}
+	require.NoError(t, err, "error fetching created network %s: %v", networkID, err)
 	assert.Equal(t, params.Name, createdNetwork.NameLabel, "created network name should match")
 	assert.Equal(t, intTests.testPool.ID.String(), createdNetwork.PoolId, "created network PoolID should match")
 
@@ -216,8 +216,5 @@ func TestCreateNetwork(t *testing.T) {
 	// For now, we use v1 client to delete the network
 	t.Log("Cleaning up network:", networkID)
 	err = intTests.v1Client.DeleteNetwork(networkID.String())
-	if err != nil {
-		t.Fatal("error deleting network:", err)
-		return
-	}
+	require.NoError(t, err, "error deleting network %s: %v", networkID, err)
 }

--- a/v2/integration/pool_test.go
+++ b/v2/integration/pool_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "github.com/vatesfr/xenorchestra-go-sdk/client"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
 )
@@ -51,6 +52,103 @@ func TestCreateVM(t *testing.T) {
 	if err != nil {
 		t.Errorf("error while deleting VM %s: %v", vmID, err)
 	}
+}
+
+func TestCreateVMWithVIFDevice(t *testing.T) {
+	ctx, client, testPrefix := SetupTestContext(t)
+
+	// Use the existing test network instead of creating a new one to avoid VLAN conflicts
+	// The test network is already available in intTests.testNetwork
+	networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+	if networkID == uuid.Nil {
+		t.Skip("No test network available, skipping VIF device test")
+	}
+
+	// Create VM with specific VIF device setting
+	vmName := "test-vm-vif-device"
+	deviceZero := payloads.StringifiedInt(0)
+
+	params := payloads.CreateVMParams{
+		NameLabel: testPrefix + vmName,
+		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		VIFs: []payloads.VIFParams{
+			{
+				Device:  &deviceZero,
+				Network: &networkID,
+			},
+		},
+	}
+
+	vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+	require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
+	require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
+
+	// Verify the VM was created and get its details
+	vm, err := client.VM().GetByID(ctx, vmID)
+	require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
+	require.NotNil(t, vm, "VM details should not be nil")
+
+	// Get the VIFs for the VM using the v1 client
+	vmObj := &v1.Vm{Id: vmID.String()}
+	vifs, err := intTests.v1Client.GetVIFs(vmObj)
+	require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
+
+	// Verify we have exactly one VIF (the one we specified)
+	assert.Equal(t, 1, len(vifs), "VM should have exactly one VIF")
+
+	// Verify the VIF has the correct device setting and network
+	assert.Equal(t, "0", vifs[0].Device, "VIF device should be '0'")
+	assert.Equal(t, networkID.String(), vifs[0].Network, "VIF should be attached to the test network")
+}
+
+// This TC is meant to verify that when a VIF is set without a device,
+// it is added to the VIFs already present on the template and not replacing them.
+func TestCreateVMWithVIFNoDevice(t *testing.T) {
+	ctx, client, testPrefix := SetupTestContext(t)
+
+	networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+	if networkID == uuid.Nil {
+		t.Skip("No test network available, skipping VIF device test")
+	}
+
+	// Create VM with specific VIF device setting
+	vmName := "test-vm-vif-device"
+	params := payloads.CreateVMParams{
+		NameLabel: testPrefix + vmName,
+		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		VIFs: []payloads.VIFParams{
+			{
+				Network: &networkID,
+			},
+		},
+	}
+
+	vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
+	require.NoError(t, err, "error while creating VM with VIF device setting: %v", err)
+	require.NotEqual(t, uuid.Nil, vmID, "created VM ID should not be nil")
+
+	// Verify the VM was created and get its details
+	vm, err := client.VM().GetByID(ctx, vmID)
+	require.NoError(t, err, "error while fetching VM details for %s: %v", vmID, err)
+	require.NotNil(t, vm, "VM details should not be nil")
+
+	// Get the VIFs for the VM using the v1 client
+	vmObj := &v1.Vm{Id: vmID.String()}
+	vifs, err := intTests.v1Client.GetVIFs(vmObj)
+	require.NoError(t, err, "error while getting VIFs for VM %s: %v", vmID, err)
+
+	// Verify we have exactly one VIF (the one we specified)
+	assert.Equal(t, 2, len(vifs), "VM should have exactly one VIF")
+
+	// Verify that one of the VIFs has the network attached
+	var vifWithNetwork *v1.VIF
+	for i := range vifs {
+		if vifs[i].Network == networkID.String() {
+			vifWithNetwork = &vifs[i]
+			assert.NotEqual(t, "0", vifs[i].Device, "VIF device shouldn't be '0'")
+		}
+	}
+	assert.NotNil(t, vifWithNetwork, "One VIF should be attached to the test network")
 }
 
 func TestCreateVMInvalidTemplate(t *testing.T) {

--- a/v2/integration/setup_test.go
+++ b/v2/integration/setup_test.go
@@ -196,7 +196,7 @@ func findPoolForTests() payloads.Pool {
 // cleanupVMsWithPrefix removes all VMs that have the testing prefix in their name
 func cleanupVMsWithPrefix(t testing.TB, client library.Library, prefix string) error {
 	t.Helper()
-	vms, err := client.VM().GetAll(intTests.ctx, 0, "name_label:"+prefix)
+	vms, err := client.VM().GetAll(intTests.ctx, 0, "name_label:\""+prefix+"\"")
 	if err != nil {
 		return fmt.Errorf("failed to get VMs: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR introduces a `StringifiedInt` type to handle fields that need to be represented as stringified numbers in JSON while maintaining integer type safety in Go code. This applies to the VIF device field, as well as the VBD position and userdevice fields.

> [!IMPORTANT]
> BREAKING CHANGES for `VIFParams` (used by `CreateVMParams` to create a VM) and for `VBD` object and `CreateVBDParams`  

## Why?

Certain fields in the XO API and XAPI are integers but must be transmitted as strings ("stringified" integers).

Ref [XAPI Documentation](https://xapi-project.github.io/xen-api/classes/vif.html):
> string **device**
> order in which VIF backends are created by xapi. Guaranteed to be an unsigned decimal integer.

The same applies to VBD `position` and `userdevice` fields.

## Benefits
- **API Compliance**: Properly handles stringified numbers as required by Xen Orchestra API
- **Type Safety**: Maintains integer type safety in Go code
- **Reusability**: Single type handles all stringified integer fields across the SDK

## Changes
- **New Type**: `StringifiedInt` in `pkg/payloads/common.go`
  - Custom type that marshal/unmarshals integers as strings in JSON

- **Updated**: `VIFParams.Device` field in `pkg/payloads/pool.go`
  - Changed from `*string` to `*StringifiedInt`

- **Updated**: `VBDParams.Position` and `VBDParams.Userdevice` fields in `pkg/payloads/vbd.go`
  - Changed from `string`/`*string` to `StringifiedInt`/`*StringifiedInt`

- **Tests**: Comprehensive test coverage
  - Unit tests for `StringifiedInt` marshaling/unmarshaling
  - Unit tests for `VIFParams` with stringified device field
  - Unit tests for `VBDParams` with stringified position and userdevice fields
  - Integration tests for both explicit and default VIF configurations