### PR TITLE
ci: add integration tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
     - cron: '11 0 * * 5'
   workflow_dispatch:
 
+
 jobs:
   analyze:
     permissions:
@@ -28,38 +29,38 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+          # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+          # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,14 +20,13 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Install go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          # The versions of golangci-lint and setup-go here cross-depend and need to update together.
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           # Either this action or golangci-lint needs to disable the cache
           cache: false
       - name: Install mockgen
-        run: go install github.com/golang/mock/mockgen@v1.6.0
+        run: go install go.uber.org/mock/mockgen@v0.6.0
       - name: Generate mocks
         run: go generate ./...
       - run: go mod tidy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,102 @@
+name: tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v*
+      - feature*
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    name: Unit Tests (v2-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run Unit Tests # Run only on v2 pkg
+        run: go test -json ./v2 ./v2/client ./pkg/... ./internal/... > unit-testresults.json
+
+      - uses: actions/upload-artifact@v7 # upload test results
+        if: ${{ !cancelled() }} # run this step even if previous step failed
+        with:
+          name: test-results
+          path: unit-testresults.json
+
+  sanity-test:
+    name: Sanity Tests (v2-only integration tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      xo-api-sim:
+        image: ghcr.io/vatesfr/xo-api-sim:latest
+        ports:
+          - 3001:3001
+        options: >-
+          --health-cmd="curl -f http://localhost:3001/ping || exit 1" --health-interval=10s --health-timeout=3s --health-retries=5
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install qemu-img
+        run: sudo apt-get update && sudo apt-get install -y qemu-utils
+
+      - name: Run Integration Tests (v2-only mode)
+        env:
+          XOA_URL: http://localhost:3001
+          XOA_TOKEN: no-token
+          XOA_POOL: "pool-01"
+          XOA_STORAGE: "NFS Default"
+          XOA_NETWORK_ID: "5a163f97-1111-2222-3333-444444444403"
+          XOA_TEMPLATE_ID: "653f9237-3612-b08e-fd43-5302cf2d537b"
+          XOA_DISABLE_V1: "true"
+          XOA_DEVELOPMENT: "true"
+          XOA_TEST_PREFIX: "ci-sanity-"
+          XOA_TEST_VLAN: "1001"
+          XOA_TEST_PBD_ID: "01393140-26fb-eddc-98b4-66bfe85daf17"
+        run: go test -json ./v2/integration > int-testresults.json
+
+      - uses: actions/upload-artifact@v7 # upload test results
+        if: ${{ !cancelled() }} # run this step even if previous step failed
+        with:
+          name: test-results
+          path: int-testresults.json
+
+  test-report:
+    name: Test Report
+    needs: [unit-test, sanity-test]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v3
+        with:
+          artifact: test-results
+          name: Golang Tests
+          path: '*.json'
+          reporter: golang-json

--- a/docs/v2/06-integration-test-guide.md
+++ b/docs/v2/06-integration-test-guide.md
@@ -48,12 +48,13 @@ Shared resources are stored in the `intTests` global variable:
 
 ```go
 type integrationTestContext struct {
-    ctx          context.Context // Parent context
-    testConfig   *config.Config  // SDK configuration
-    testPool     payloads.Pool   // Pool used for testing (v2)
-    testTemplate v1.Template     // Template used for VM creation (v1)
-    testNetwork  v1.Network      // Network used for tests (v1)
-    v1Client     v1.XOClient     // Client for missing v2 features
+    ctx             context.Context // Parent context
+    testConfig      *config.Config  // SDK configuration
+    testPool        payloads.Pool   // Pool used for testing (v2)
+    testTemplateID  string          // Template UUID for VM creation
+    testNetworkID   string          // Network UUID for tests
+    v1Disabled      bool            // Whether v1 client is disabled
+    v1Client        v1.XOClient     // Client for missing v2 features (nil if disabled)
 }
 ```
 
@@ -86,12 +87,45 @@ Common utility functions used across multiple test files are centralized in `hel
 | `XOA_TOKEN` | Authentication token | `xxxxxxx` | If no credentials |
 | `XOA_POOL` | Test pool Name Label | `My Pool` | ✅ |
 | `XOA_STORAGE` | Test storage repository Name Label | `My SR` | ✅ |
-| `XOA_TEMPLATE` | Template Name Label | `Alpine 3.10` | ✅ |
-| `XOA_NETWORK` | Network used for test | `My Network` | ✅ |
+| `XOA_TEMPLATE` | Template Name Label (legacy) | `Alpine 3.10` | Legacy — use `XOA_TEMPLATE_ID` instead |
+| `XOA_NETWORK` | Network Name Label (legacy) | `My Network` | Legacy — use `XOA_NETWORK_ID` instead |
+| `XOA_TEMPLATE_ID` | Direct template UUID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Preferred over `XOA_TEMPLATE` |
+| `XOA_NETWORK_ID` | Direct network UUID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Preferred over `XOA_NETWORK` |
+| `XOA_DISABLE_V1` | Disable v1 client (v2-only mode) | `true` | ❌ |
 | `XOA_DEVELOPMENT`| Enable debug logs | `true` | ❌ |
 | `XOA_TEST_PREFIX`| Custom resource prefix | `ci-` | ❌ |
 | `XOA_TEST_VLAN`  | VLAN for network tests | `1234` | ❌ |
 | `XOA_TEST_PBD_ID`| UUID of a PBD safe to plug/unplug (e.g. removable storage). Required for PBD plug/unplug tests; uuid.Nil when unset. | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | ❌ |
+
+### Running Modes
+
+The integration test suite supports two modes:
+
+**Hybrid Mode (Default)**: Uses the v2 SDK for primary operations and falls back to the v1 client for resource discovery (templates, networks) and cleanup tasks not yet available in v2.
+
+**v2-Only Mode**: Set `XOA_DISABLE_V1=true` to disable the v1 client entirely. In this mode:
+- `XOA_TEMPLATE_ID` and `XOA_NETWORK_ID` are **required** (no fallback to name-based discovery).
+- Tests that depend on the v1 client (network creation, VIF device tests) are automatically skipped.
+- v2 cleanup paths (VMs, VDIs) remain active.
+
+### Running the Suite
+
+```bash
+# Hybrid mode (default)
+export XOA_URL="https://xoa.lab.local"
+export XOA_TOKEN="token"
+export XOA_POOL="Pool A"
+export XOA_TEMPLATE="Alpine 3.10"
+export XOA_STORAGE="storage repository name"
+
+make test-integration
+
+# v2-only mode
+export XOA_TEMPLATE_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export XOA_NETWORK_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export XOA_DISABLE_V1=true
+make test-integration
+```
 
 ### Test Template Guidance
 
@@ -131,7 +165,7 @@ func TestCreateVM(t *testing.T) {
     vmName := prefix + "my-vm"
     params := &payloads.CreateVMParams{
         NameLabel: vmName,
-        Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+        Template:  uuid.FromStringOrNil(intTests.testTemplateID),
     }
 
     // 3. Execute v2 operation

--- a/v2/integration/README.md
+++ b/v2/integration/README.md
@@ -28,8 +28,15 @@ export XOA_PASSWORD="password"
 export XOA_TOKEN="token"
 
 export XOA_POOL="pool-name"
-export XOA_TEMPLATE="template-name"
+export XOA_TEMPLATE_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export XOA_NETWORK_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 export XOA_STORAGE="storage-repository-name"
+```
+
+Legacy alternative (name-based, requires v1 client):
+```bash
+export XOA_TEMPLATE="template-name"
+export XOA_NETWORK="network-name"
 ```
 
 Optional:
@@ -67,7 +74,7 @@ func TestMyFeature(t *testing.T) {
 3. Key points:
    - Always `ctx, client, prefix := SetupTestContext(t)`
    - Prefix resources: `prefix + "my-vm"`
-   - Use: `client` (local), `intTests.testPool`, `intTests.testTemplate`, `intTests.testNetwork`
+   - Use: `client` (local), `intTests.testPool`, `intTests.testTemplateID`, `intTests.testNetworkID`
    - Unexpected errors: `require.NoError`
    - Verifications: `assert.Equal`
 
@@ -76,9 +83,10 @@ func TestMyFeature(t *testing.T) {
 Shared resources are available via the `intTests` global variable:
 
 - `intTests.testPool` (payloads.Pool) - Test pool
-- `intTests.testTemplate` (v1.Template) - VM template
-- `intTests.testNetwork` (v1.Network) - Pool network
-- `intTests.v1Client` (v1.XOClient) - v1 client for setup/teardown tasks
+- `intTests.testTemplateID` (string) - Test template UUID (from `XOA_TEMPLATE_ID` or v1 fallback)
+- `intTests.testNetworkID` (string) - Test network UUID (from `XOA_NETWORK_ID` or v1 fallback)
+- `intTests.testSR` (payloads.StorageRepository) - Storage repository for VDI tests
+- `intTests.v1Client` (v1.XOClient) - v1 client for setup/teardown tasks (nil if `XOA_DISABLE_V1=true`)
 
 ## Common Patterns
 
@@ -100,7 +108,7 @@ vms, _ := client.VM().GetAll(ctx, 0, "name_label:"+prefix)
 ```go
 params := payloads.CreateVMParams{
     NameLabel: prefix + "vm-name",
-    Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+    Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 }
 vmID, _ := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
 ```

--- a/v2/integration/client_test.go
+++ b/v2/integration/client_test.go
@@ -13,6 +13,9 @@ import (
 // TestV1ClientLazyInitializationWithRealConnection tests that the v1 client is
 // initialized lazily when accessed, and that it works with a real connection
 func TestV1ClientLazyInitializationWithRealConnection(t *testing.T) {
+	if intTests.v1Disabled {
+		t.Skip("v1 client disabled, skipping v1 lazy initialization test")
+	}
 
 	// Create a new client
 	cfg, err := config.New()

--- a/v2/integration/helpers_test.go
+++ b/v2/integration/helpers_test.go
@@ -24,7 +24,7 @@ func createVMsForTest(t *testing.T, ctx context.Context, pool library.Pool, coun
 		vmName := name + uuid.Must(uuid.NewV4()).String()
 		params := payloads.CreateVMParams{
 			NameLabel: vmName,
-			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		}
 
 		vmID, err := pool.CreateVM(ctx, intTests.testPool.ID, params)

--- a/v2/integration/pool_test.go
+++ b/v2/integration/pool_test.go
@@ -40,7 +40,7 @@ func TestCreateVM(t *testing.T) {
 		vmName := "test-vm"
 		params := payloads.CreateVMParams{
 			NameLabel: testPrefix + vmName,
-			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		}
 
 		vmID, err := client.Pool().CreateVM(ctx, intTests.testPool.ID, params)
@@ -56,11 +56,14 @@ func TestCreateVM(t *testing.T) {
 
 	t.Run("WithVIFDevice", func(t *testing.T) {
 		t.Parallel()
+		if intTests.v1Disabled {
+			t.Skip("v1 client disabled, skipping VIF device test")
+		}
 		ctx, client, testPrefix := SetupTestContext(t)
 
 		// Use the existing test network instead of creating a new one to avoid VLAN conflicts
 		// The test network is already available in intTests.testNetwork
-		networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+		networkID := uuid.FromStringOrNil(intTests.testNetworkID)
 		if networkID == uuid.Nil {
 			t.Skip("No test network available, skipping VIF device test")
 		}
@@ -71,7 +74,7 @@ func TestCreateVM(t *testing.T) {
 
 		params := payloads.CreateVMParams{
 			NameLabel: testPrefix + vmName,
-			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 			VIFs: []payloads.VIFParams{
 				{
 					Device:  &deviceZero,
@@ -106,9 +109,12 @@ func TestCreateVM(t *testing.T) {
 	// it is added to the VIFs already present on the template and not replacing them.
 	t.Run("WithVIFNoDevice", func(t *testing.T) {
 		t.Parallel()
+		if intTests.v1Disabled {
+			t.Skip("v1 client disabled, skipping VIF no-device test")
+		}
 		ctx, client, testPrefix := SetupTestContext(t)
 
-		networkID := uuid.FromStringOrNil(intTests.testNetwork.Id)
+		networkID := uuid.FromStringOrNil(intTests.testNetworkID)
 		if networkID == uuid.Nil {
 			t.Skip("No test network available, skipping VIF device test")
 		}
@@ -117,7 +123,7 @@ func TestCreateVM(t *testing.T) {
 		vmName := "test-vm-vif-device"
 		params := payloads.CreateVMParams{
 			NameLabel: testPrefix + vmName,
-			Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+			Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 			VIFs: []payloads.VIFParams{
 				{
 					Network: &networkID,
@@ -172,6 +178,9 @@ func TestCreateVM(t *testing.T) {
 }
 
 func TestCreateNetwork(t *testing.T) {
+	if intTests.v1Disabled {
+		t.Skip("v1 client disabled, skipping network creation test")
+	}
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	networkName := "test-network"
@@ -184,9 +193,16 @@ func TestCreateNetwork(t *testing.T) {
 			t.Logf("Ignoring invalid XOA_TEST_VLAN=%s, using default %d", v, vlan)
 		}
 	}
+	// Resolve PIF from the test network via v1 client
+	testNetwork, err := intTests.v1Client.GetNetwork(v1.Network{
+		Id: intTests.testNetworkID,
+	})
+	require.NoError(t, err, "error fetching test network %s: %v", intTests.testNetworkID, err)
+	require.GreaterOrEqual(t, len(testNetwork.PIFs), 1, "test network should have at least one PIF")
+
 	params := payloads.CreateNetworkParams{
 		Name:        testPrefix + networkName,
-		Pif:         uuid.FromStringOrNil(intTests.testNetwork.PIFs[0]), // Use the first PIF, only one PIF is expected
+		Pif:         uuid.FromStringOrNil(testNetwork.PIFs[0]),
 		MTU:         &[]uint{1450}[0],
 		Description: "Test network created by xo-sdk-go",
 		Vlan:        vlan,

--- a/v2/integration/setup_test.go
+++ b/v2/integration/setup_test.go
@@ -31,15 +31,21 @@ type integrationTestContext struct {
 	// testSR holds a storage repository used for VDI-related tests
 	testSR payloads.StorageRepository
 
-	// TODO: replace v1 struct by payloads.STRUCT when available in v2
+	// testTemplateID holds the template UUID used for VM creation tests.
+	// Resolved from XOA_TEMPLATE_ID (direct) or v1 discovery (fallback).
+	testTemplateID string
 
-	// testTemplate holds a template used for VM creation tests
-	testTemplate v1.Template
-	// testNetwork holds a network used for network-related tests
-	testNetwork v1.Network
+	// testNetworkID holds the network UUID used for network-related tests.
+	// Resolved from XOA_NETWORK_ID (direct) or v1 discovery (fallback).
+	testNetworkID string
 
-	// v1Client is the XO client used for resources not yet available in v2
-	// Should not be used to perform the actual test but only to setup/teardown resources
+	// v1Disabled is true when XOA_DISABLE_V1=true.
+	// When true, v1Client is nil and v1-dependent tests are skipped.
+	v1Disabled bool
+
+	// v1Client is the XO client used for resources not yet available in v2.
+	// Should not be used to perform the actual test but only to setup/teardown resources.
+	// Nil when v1Disabled is true.
 	v1Client v1.XOClient
 
 	// testPBD is the UUID of a PBD that is safe to temporarily plug/unplug during tests.
@@ -73,13 +79,15 @@ func TestMain(m *testing.M) {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, handlerOpt))
 	slog.SetDefault(logger)
 	slog.SetLogLoggerLevel(slog.LevelDebug)
-	// TODO: v1 helpers don't log errors with this logger (e.g. v1.FindTemplateForTests)
 
 	// XO client configuration via environment variables
 	// - XOA_URL: XO API URL (required)
 	// - XOA_USER and XOA_PASSWORD: Credentials (required if no token)
 	// - XOA_TOKEN: Authentication token (required if no credentials)
 	// - XOA_DEVELOPMENT: true to enable development logs
+	// - XOA_DISABLE_V1: true to disable v1 client (requires XOA_TEMPLATE_ID and XOA_NETWORK_ID)
+	// - XOA_TEMPLATE_ID: direct template UUID (takes precedence over v1 discovery)
+	// - XOA_NETWORK_ID: direct network UUID (takes precedence over v1 discovery)
 	intTests.testConfig, err = config.New()
 	if err != nil {
 		log.Fatalf("configuration failed: %v", err)
@@ -88,20 +96,56 @@ func TestMain(m *testing.M) {
 	// Force development mode for tests
 	intTests.testConfig.Development = devMode
 
-	// Initialize v1 client for setup/teardown tasks
-	intTests.v1Client, err = v1.NewClientWithLogger(v1.GetConfigFromEnv(), logger)
-	if err != nil {
-		integrationCancel()
-		log.Fatalf("error getting v1.client %s", err)
+	// Determine v1 status
+	intTests.v1Disabled, _ = strconv.ParseBool(os.Getenv("XOA_DISABLE_V1"))
+
+	// Resolve template ID: direct env var takes precedence, fallback to v1 discovery
+	if templateID, found := os.LookupEnv("XOA_TEMPLATE_ID"); found && templateID != "" {
+		intTests.testTemplateID = templateID
+	}
+
+	// Resolve network ID: direct env var takes precedence, fallback to v1 discovery
+	if networkID, found := os.LookupEnv("XOA_NETWORK_ID"); found && networkID != "" {
+		intTests.testNetworkID = networkID
+	}
+
+	// When v1 is disabled, both direct IDs must be provided
+	if intTests.v1Disabled {
+		if intTests.testTemplateID == "" {
+			integrationCancel()
+			log.Fatal("XOA_DISABLE_V1=true requires XOA_TEMPLATE_ID to be set")
+		}
+		if intTests.testNetworkID == "" {
+			integrationCancel()
+			log.Fatal("XOA_DISABLE_V1=true requires XOA_NETWORK_ID to be set")
+		}
 	}
 
 	// Get information for testing
 	intTests.testPool = findPoolForTests()
-	// TODO: Replace v1 method with v2 when available
-	v1.FindNetworkForTests(intTests.testPool.ID.String(), &intTests.testNetwork)
-	v1.FindTemplateForTests(&intTests.testTemplate, intTests.testPool.ID.String(), "XOA_TEMPLATE")
 	intTests.testSR = findStorageRepositoryForTests()
 	intTests.testPBD = findPBDForTests()
+
+	// Initialize v1 client only when needed for discovery or v1-dependent teardown
+	if !intTests.v1Disabled {
+		intTests.v1Client, err = v1.NewClientWithLogger(v1.GetConfigFromEnv(), logger)
+		if err != nil {
+			integrationCancel()
+			log.Fatalf("error getting v1.client %s", err)
+		}
+
+		// Fallback to v1 discovery when direct IDs are not provided
+		if intTests.testTemplateID == "" {
+			var tmpl v1.Template
+			v1.FindTemplateForTests(&tmpl, intTests.testPool.ID.String(), "XOA_TEMPLATE")
+			intTests.testTemplateID = tmpl.Id
+		}
+		if intTests.testNetworkID == "" {
+			var net v1.Network
+			v1.FindNetworkForTests(intTests.testPool.ID.String(), &net)
+			intTests.testNetworkID = net.Id
+		}
+	}
 
 	// Get resource test prefix from environment variable if set
 	if prefix, found := os.LookupEnv("XOA_TEST_PREFIX"); found {
@@ -145,20 +189,24 @@ func SetupTestContext(t *testing.T) (context.Context, library.Library, string) {
 	}
 
 	// Make the V1Client use t.Logf
-	handler := slog.NewTextHandler(&testLogWriter{t}, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	})
-	if client, ok := intTests.v1Client.(*v1.Client); ok {
-		client.SetLogger(slog.New(handler))
+	if !intTests.v1Disabled {
+		handler := slog.NewTextHandler(&testLogWriter{t}, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})
+		if client, ok := intTests.v1Client.(*v1.Client); ok {
+			client.SetLogger(slog.New(handler))
+		}
 	}
 
 	// Register teardown function
 	t.Cleanup(func() {
 		cancel() // Cancel the test context
-		// Teardown: cleanup any leftover test VMs and networks
+		// Teardown: cleanup any leftover
 		_ = cleanupVMsWithPrefix(t, testClient, prefix)
-		_ = v1.RemoveNetworksWithNamePrefixForTests(prefix)("")
-		_ = v1.RemoveVDIsWithPrefixForTests(prefix)("")
+		if !intTests.v1Disabled {
+			_ = v1.RemoveNetworksWithNamePrefixForTests(prefix)("")
+			_ = v1.RemoveVDIsWithPrefixForTests(prefix)("")
+		}
 	})
 
 	return ctx, testClient, prefix

--- a/v2/integration/setup_test.go
+++ b/v2/integration/setup_test.go
@@ -291,7 +291,7 @@ func findStorageRepositoryForTests() payloads.StorageRepository {
 		log.Fatalf("XOA_STORAGE environment variable must be set")
 	}
 
-	srs, err := client.SR().GetAll(intTests.ctx, 0, "name_label:"+srName+" $pool:"+intTests.testPool.ID.String())
+	srs, err := client.SR().GetAll(intTests.ctx, 0, "name_label:\""+srName+"\" $pool:"+intTests.testPool.ID.String())
 	if err != nil {
 		log.Fatalf("failed to get storage repository with name: %s, with err: %v", srName, err)
 	}

--- a/v2/integration/vbds_test.go
+++ b/v2/integration/vbds_test.go
@@ -18,7 +18,7 @@ func TestVBDGet(t *testing.T) {
 	// Create a VM — it comes with at least one system-disk VBD.
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-get-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	})
 	require.NoError(t, err, "creating VM should succeed")
 	require.NotEmpty(t, vm.VBDs, "VM should have at least one VBD")
@@ -49,7 +49,7 @@ func TestVBDGetAll(t *testing.T) {
 	// Create a VM with two extra data disks so we have a known set of VBDs to filter on.
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-getall-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		VDIs: []payloads.VDIParams{
 			{
 				NameLabel: ptr(testPrefix + "vbd-getall-vdi-1"),
@@ -107,7 +107,7 @@ func TestVBDCreate(t *testing.T) {
 
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-create-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	})
 	require.NoError(t, err, "creating VM should succeed")
 
@@ -144,7 +144,7 @@ func TestVBDDelete(t *testing.T) {
 
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-delete-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	})
 	require.NoError(t, err, "creating VM should succeed")
 
@@ -172,7 +172,7 @@ func TestVBDConnectDisconnect(t *testing.T) {
 	// Create and start a VM.
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-connect-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	})
 	require.NoError(t, err, "creating VM should succeed")
@@ -225,7 +225,7 @@ func TestVBDGetTasks(t *testing.T) {
 	// Create and start a VM.
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-connect-vm",
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	})
 	require.NoError(t, err, "creating VM should succeed")

--- a/v2/integration/vdis_test.go
+++ b/v2/integration/vdis_test.go
@@ -155,12 +155,14 @@ func TestVDIGetTasks(t *testing.T) {
 	require.NoError(t, err, "migration task should complete successfully")
 	require.NotNil(t, task, "migration task result should not be nil")
 	require.Equal(t, payloads.Success, task.Status, "migration task should complete successfully")
+	vdiTestID = task.Result.ID // Update vdiTestID to the new VDI ID after migration
 	taskID2, err := client.VDI().Migrate(ctx, vdiTestID, intTests.testSR.ID)
 	require.NoError(t, err, "2nd migrating VDI should succeed")
 	task, err = client.Task().Wait(ctx, taskID2)
 	require.NoError(t, err, "migration task should complete successfully")
 	require.NotNil(t, task, "migration task result should not be nil")
 	require.Equal(t, payloads.Success, task.Status, "migration task should complete successfully")
+	vdiTestID = task.Result.ID // Update vdiTestID to the new VDI ID after migration
 
 	t.Run("GetTasksSuccess", func(t *testing.T) {
 		t.Parallel()

--- a/v2/integration/vms_test.go
+++ b/v2/integration/vms_test.go
@@ -18,7 +18,7 @@ func TestVmCreation(t *testing.T) {
 	vmName := testPrefix + "creation-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	}
 
 	vmID, err := client.VM().Create(ctx, intTests.testPool.ID, params)
@@ -33,7 +33,7 @@ func TestVmDeletion(t *testing.T) {
 	vmName := testPrefix + "deletion-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	}
 
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, params)
@@ -55,7 +55,7 @@ func TestVmStart(t *testing.T) {
 	vmName := testPrefix + "start-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 	}
 
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, params)
@@ -82,7 +82,7 @@ func TestVmHardShutdown(t *testing.T) {
 	vmName := testPrefix + "hard-shutdown-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -107,7 +107,7 @@ func TestVmCleanShutdown(t *testing.T) {
 	vmName := testPrefix + "clean-shutdown-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -135,7 +135,7 @@ func TestVmCleanReboot(t *testing.T) {
 	vmName := testPrefix + "clean-reboot-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -163,7 +163,7 @@ func TestVmHardReboot(t *testing.T) {
 	vmName := testPrefix + "hard-reboot-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -188,7 +188,7 @@ func TestVmPauseUnpause(t *testing.T) {
 	vmName := testPrefix + "pause-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -223,7 +223,7 @@ func TestVmSuspendResume(t *testing.T) {
 	vmName := testPrefix + "suspend-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -260,7 +260,7 @@ func TestVmSnapshot(t *testing.T) {
 	vmName := testPrefix + "snapshot-test-" + uuid.Must(uuid.NewV4()).String()
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
 	}
 
@@ -348,7 +348,7 @@ func TestVMGetVDIs(t *testing.T) {
 	vmName := testPrefix + "get-vdis-test"
 	params := &payloads.CreateVMParams{
 		NameLabel: vmName,
-		Template:  uuid.FromStringOrNil(intTests.testTemplate.Id),
+		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		VDIs: []payloads.VDIParams{
 			{
 				NameLabel: ptr(testPrefix + "vm-vdi-1"),

--- a/v2/integration/vms_test.go
+++ b/v2/integration/vms_test.go
@@ -324,7 +324,7 @@ func testVMListWithNoLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, vms)
 	// Adjust expectation - we now create only 5 VMs, but there might be other VMs in the system
-	assert.Greater(t, len(vms), 5, "expected more than 5 VMs in total")
+	assert.GreaterOrEqual(t, len(vms), 5, "expected at least 5 VMs in total")
 }
 
 func testVMListWithFilter(t *testing.T) {


### PR DESCRIPTION
The idea is to run integration test with a mocked Xo API using https://github.com/vatesfr/xo-api-sim
This is not a complete integration test, but a sanity check of the API client.

This is only for the REST API calls, so this PR add an option to disable v1 SDK usage in the tests with `XOA_DISABLE_V1=true`. Also it replaces environment variables `XOA_TEMPLATE` by `XOA_TEMPLATE_ID` and `XOA_NETWORK` by `XOA_NETWORK_ID` to avoid using v1 to lookup for network and template.