### PR TITLE
Fix integration tests after sdk update and new XO release

### DIFF
--- a/docs/v2/06-integration-test-guide.md
+++ b/docs/v2/06-integration-test-guide.md
@@ -88,9 +88,9 @@ Common utility functions used across multiple test files are centralized in `hel
 | `XOA_POOL` | Test pool Name Label | `My Pool` | ✅ |
 | `XOA_STORAGE` | Test storage repository Name Label | `My SR` | ✅ |
 | `XOA_TEMPLATE` | Template Name Label (legacy) | `Alpine 3.10` | Legacy — use `XOA_TEMPLATE_ID` instead |
-| `XOA_NETWORK` | Network Name Label (legacy) | `My Network` | Legacy — use `XOA_NETWORK_ID` instead |
+| `XOA_NETWORK` | Network Name Label (legacy, must refer to a non-VLAN network) | `My Network` | Legacy — use `XOA_NETWORK_ID` instead |
 | `XOA_TEMPLATE_ID` | Direct template UUID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Preferred over `XOA_TEMPLATE` |
-| `XOA_NETWORK_ID` | Direct network UUID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Preferred over `XOA_NETWORK` |
+| `XOA_NETWORK_ID` | Direct network UUID (must refer to a non-VLAN network) | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Preferred over `XOA_NETWORK` |
 | `XOA_DISABLE_V1` | Disable v1 client (v2-only mode) | `true` | ❌ |
 | `XOA_DEVELOPMENT`| Enable debug logs | `true` | ❌ |
 | `XOA_TEST_PREFIX`| Custom resource prefix | `ci-` | ❌ |
@@ -130,6 +130,12 @@ make test-integration
 ### Test Template Guidance
 
 Choose a test template that boots quickly and has the Xen Orchestra guest agent installed so the VM becomes reachable before the 5-minute test timeout. Integration tests read the VM's main IP address from the guest agent, so templates without it risk timing out or returning no address.
+
+### Test Network Guidance
+
+The integration test network must be a non-VLAN network, whether selected by UUID (`XOA_NETWORK_ID`) or by name (`XOA_NETWORK`).
+
+Do not point `XOA_NETWORK_ID` or `XOA_NETWORK` to a VLAN-backed network. Some network tests create additional VLAN networks and rely on a regular network as the base reference.
 
 ### Running the Suite
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 )
 
 require (
-	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/pkg/payloads/pool.go
+++ b/pkg/payloads/pool.go
@@ -49,12 +49,12 @@ type InstallParams struct {
 }
 
 type VDIParams struct {
-	Destroy         *bool   `json:"destroy,omitempty"`
-	UserDevice      *string `json:"userdevice,omitempty"`
-	Size            *int64  `json:"size,omitempty"` // Using int64 for size as it can be large
-	SR              *string `json:"sr,omitempty"`
-	NameDescription *string `json:"name_description,omitempty"`
-	NameLabel       *string `json:"name_label,omitempty"`
+	Destroy         *bool      `json:"destroy,omitempty"`
+	UserDevice      *string    `json:"userdevice,omitempty"`
+	Size            *int64     `json:"size,omitempty"` // Using int64 for size as it can be large
+	SR              *uuid.UUID `json:"sr,omitempty"`
+	NameDescription *string    `json:"name_description,omitempty"`
+	NameLabel       *string    `json:"name_label,omitempty"`
 }
 
 type VIFParams struct {

--- a/v2/integration/helpers_test.go
+++ b/v2/integration/helpers_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "github.com/vatesfr/xenorchestra-go-sdk/client"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/payloads"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/services/library"
 )
@@ -184,16 +183,11 @@ func createTestDiskImage(t *testing.T, format string, size int64) string {
 
 func createNetworkForTest(t *testing.T, ctx context.Context, client library.Library, name string) uuid.UUID {
 	t.Helper()
-	if intTests.v1Disabled {
-		// For the tests we only need an internal network.
-		// The current v2 does not support creating internal network.
-		t.Skip("v1 client disabled, skipping v1 lazy initialization test")
-	}
-	network, err := client.V1Client().CreateNetwork(v1.CreateNetworkRequest{
-		Name:        name,
-		Pool:        intTests.testPool.ID.String(),
-		Description: "Temporary network for integration test",
-	})
+	networkID, err := client.Pool().CreateInternalNetwork(
+		ctx, intTests.testPool.PoolID, payloads.CreateInternalNetworkParams{
+			Name: name,
+		})
 	require.NoError(t, err, "creating network should succeed")
-	return uuid.FromStringOrNil(network.Id)
+	require.NotEqual(t, uuid.Nil, networkID, "returned networkID should not be nil")
+	return networkID
 }

--- a/v2/integration/setup_test.go
+++ b/v2/integration/setup_test.go
@@ -204,9 +204,7 @@ func SetupTestContext(t *testing.T) (context.Context, library.Library, string) {
 		// Teardown: cleanup any leftover
 		_ = cleanupVMsWithPrefix(t, testClient, prefix)
 		_ = cleanupNetworksWithPrefix(t, testClient, prefix)
-		if !intTests.v1Disabled {
-			_ = v1.RemoveVDIsWithPrefixForTests(prefix)("")
-		}
+		_ = cleanupVDIWithPrefix(t, testClient, prefix)
 	})
 
 	return ctx, testClient, prefix
@@ -280,6 +278,27 @@ func cleanupNetworksWithPrefix(t testing.TB, client library.Library, prefix stri
 			if err != nil {
 				t.Logf("failed to delete Network NameLabel=%s error=%v", network.NameLabel, err)
 				return fmt.Errorf("failed to delete Network %s: %v", network.NameLabel, err)
+			}
+		}
+	}
+	return nil
+}
+
+func cleanupVDIWithPrefix(t testing.TB, client library.Library, prefix string) error {
+	t.Helper()
+	vdis, err := client.VDI().GetAll(intTests.ctx, 0, "name_label:\""+prefix+"\"")
+	if err != nil {
+		return fmt.Errorf("failed to get VDIs: %v", err)
+	}
+
+	for _, vdi := range vdis {
+		// Check that VDI name starts with the test prefix
+		if len(vdi.NameLabel) >= len(prefix) && (vdi.NameLabel)[:len(prefix)] == prefix {
+			// t.Logf("Found remaining test VDI, Deleting test... NameLabel=%s ID=%s", vdi.NameLabel, vdi.ID)
+			err := client.VDI().Delete(intTests.ctx, vdi.ID)
+			if err != nil {
+				t.Logf("failed to delete VDI NameLabel=%s error=%v", vdi.NameLabel, err)
+				return fmt.Errorf("failed to delete VDI %s: %v", vdi.NameLabel, err)
 			}
 		}
 	}

--- a/v2/integration/srs_test.go
+++ b/v2/integration/srs_test.go
@@ -121,11 +121,9 @@ func TestSRScan(t *testing.T) {
 		// The POST succeeds (200) and returns a task ID even for a non-existent SR.
 		// The task then fails asynchronously with result.message="no such object {id}".
 		taskID, err := client.SR().Scan(ctx, uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"))
-		require.NoError(t, err, "Scan should return a task ID even for a non-existent SR")
-		require.NotEmpty(t, taskID, "Scan should return a non-empty task ID")
-
-		task := waitForTask(t, ctx, client, taskID)
-		assert.Equal(t, payloads.Failure, task.Status, "Scan task for a non-existent SR should fail")
+		require.Error(t, err, "Scan should return a 404 error for a non-existent SR")
+		require.Empty(t, taskID, "Scan should return an empty task ID")
+		assert.Contains(t, err.Error(), "API error: 404 Not Found", "error message should indicate 404 Not Found")
 	})
 }
 
@@ -149,11 +147,9 @@ func TestSRReclaimSpace(t *testing.T) {
 		// The POST succeeds (200) and returns a task ID even for a non-existent SR.
 		// The task then fails asynchronously with result.message="no such object {id}".
 		taskID, err := client.SR().ReclaimSpace(ctx, uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426655440000"))
-		require.NoError(t, err, "ReclaimSpace should return a task ID even for a non-existent SR")
-		require.NotEmpty(t, taskID, "ReclaimSpace should return a non-empty task ID")
-
-		task := waitForTask(t, ctx, client, taskID)
-		assert.Equal(t, payloads.Failure, task.Status, "ReclaimSpace task for a non-existent SR should fail")
+		require.Error(t, err, "ReclaimSpace should return a 404 error for a non-existent SR")
+		assert.Contains(t, err.Error(), "API error: 404 Not Found", "error message should indicate 404 Not Found")
+		require.Empty(t, taskID, "ReclaimSpace should return an empty task ID")
 	})
 }
 

--- a/v2/integration/vbds_test.go
+++ b/v2/integration/vbds_test.go
@@ -19,6 +19,13 @@ func TestVBDGet(t *testing.T) {
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-get-vm",
 		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
+		VDIs: []payloads.VDIParams{
+			{
+				NameLabel: ptr(testPrefix + "vbd-get-vdi"),
+				Size:      ptr(int64(512 * units.MB)),
+				SR:        ptr(intTests.testSR.ID),
+			},
+		},
 	})
 	require.NoError(t, err, "creating VM should succeed")
 	require.NotEmpty(t, vm.VBDs, "VM should have at least one VBD")
@@ -54,10 +61,12 @@ func TestVBDGetAll(t *testing.T) {
 			{
 				NameLabel: ptr(testPrefix + "vbd-getall-vdi-1"),
 				Size:      ptr(int64(512 * units.MB)),
+				SR:        ptr(intTests.testSR.ID),
 			},
 			{
 				NameLabel: ptr(testPrefix + "vbd-getall-vdi-2"),
 				Size:      ptr(int64(512 * units.MB)),
+				SR:        ptr(intTests.testSR.ID),
 			},
 		},
 	})
@@ -108,6 +117,7 @@ func TestVBDCreate(t *testing.T) {
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-create-vm",
 		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
+		VDIs:      []payloads.VDIParams{},
 	})
 	require.NoError(t, err, "creating VM should succeed")
 
@@ -145,6 +155,13 @@ func TestVBDDelete(t *testing.T) {
 	vm, err := client.VM().Create(ctx, intTests.testPool.ID, &payloads.CreateVMParams{
 		NameLabel: testPrefix + "vbd-delete-vm",
 		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
+		VDIs: []payloads.VDIParams{
+			{
+				NameLabel: ptr(testPrefix + "vbd-delete-vdi"),
+				Size:      ptr(int64(512 * units.MB)),
+				SR:        ptr(intTests.testSR.ID),
+			},
+		},
 	})
 	require.NoError(t, err, "creating VM should succeed")
 
@@ -174,6 +191,13 @@ func TestVBDConnectDisconnect(t *testing.T) {
 		NameLabel: testPrefix + "vbd-connect-vm",
 		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
+		VDIs: []payloads.VDIParams{
+			{
+				NameLabel: ptr(testPrefix + "vbd-connect-vdi-os"),
+				Size:      ptr(int64(4 * units.GB)),
+				SR:        ptr(intTests.testSR.ID),
+			},
+		},
 	})
 	require.NoError(t, err, "creating VM should succeed")
 	require.Equal(t, vm.PowerState, payloads.PowerStateRunning, "VM should be running after creation with Boot=true")
@@ -227,6 +251,13 @@ func TestVBDGetTasks(t *testing.T) {
 		NameLabel: testPrefix + "vbd-connect-vm",
 		Template:  uuid.FromStringOrNil(intTests.testTemplateID),
 		Boot:      ptr(true),
+		VDIs: []payloads.VDIParams{
+			{
+				NameLabel: ptr(testPrefix + "vbd-connect-vdi-os"),
+				Size:      ptr(int64(4 * units.GB)),
+				SR:        ptr(intTests.testSR.ID),
+			},
+		},
 	})
 	require.NoError(t, err, "creating VM should succeed")
 	require.Equal(t, vm.PowerState, payloads.PowerStateRunning, "VM should be running after creation with Boot=true")

--- a/v2/integration/vdis_test.go
+++ b/v2/integration/vdis_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestVDIGet(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vdiTestID1 := createVDIForTest(t, ctx, client, testPrefix+"vdi1", 512*units.MB)
@@ -69,7 +68,6 @@ func vdiTagExists(ctx context.Context, client library.Library, vdiID uuid.UUID, 
 }
 
 func TestVDITags(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vdiTestID := createVDIForTest(t, ctx, client, testPrefix+"vdi-tags", 512*units.MB)
@@ -99,7 +97,6 @@ func TestVDITags(t *testing.T) {
 }
 
 func TestVDIDeletion(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vdiTestID := createVDIForTest(t, ctx, client, testPrefix+"vdi-delete", 512*units.MB)
@@ -111,7 +108,6 @@ func TestVDIDeletion(t *testing.T) {
 }
 
 func TestVDIMigration(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vdiTestID := createVDIForTest(t, ctx, client, testPrefix+"vdi-migrate", 512*units.MB)
@@ -144,7 +140,6 @@ func TestVDIMigration(t *testing.T) {
 }
 
 func TestVDIGetTasks(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	// Create and migrate the VDI multiple times to generate some tasks
@@ -202,13 +197,11 @@ func TestVDIGetTasks(t *testing.T) {
 }
 
 func TestVDIExport(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vdiTestID := createVDIForTest(t, ctx, client, testPrefix+"vdi-export-import", 10*units.MB)
 
 	t.Run("export in raw", func(t *testing.T) {
-		t.Parallel()
 
 		err := client.VDI().Export(ctx, vdiTestID, payloads.VDIFormatRaw, func(reader io.Reader) error {
 			// Verify the exported content is in raw format using qemu-img
@@ -219,7 +212,6 @@ func TestVDIExport(t *testing.T) {
 	})
 
 	t.Run("export in vhd", func(t *testing.T) {
-		t.Parallel()
 
 		err := client.VDI().Export(ctx, vdiTestID, payloads.VDIFormatVHD, func(reader io.Reader) error {
 			// Verify the exported content is in VHD format using qemu-img
@@ -233,11 +225,9 @@ func TestVDIExport(t *testing.T) {
 }
 
 func TestVDIImportExport(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	t.Run("with raw disk", func(t *testing.T) {
-		t.Parallel()
 
 		// Create a VDI to import into
 		vdiID := createVDIForTest(t, ctx, client, testPrefix+"vdi-import-raw", 10*units.MB)
@@ -268,7 +258,6 @@ func TestVDIImportExport(t *testing.T) {
 	})
 
 	t.Run("with vhd disk", func(t *testing.T) {
-		t.Parallel()
 
 		// Create a VDI to import into
 		vdiID := createVDIForTest(t, ctx, client, testPrefix+"vdi-import-vhd", 10*units.MB)
@@ -300,7 +289,6 @@ func TestVDIImportExport(t *testing.T) {
 }
 
 func TestVDICreate(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	t.Run("CreateVDIWithName", func(t *testing.T) {

--- a/v2/integration/vms_test.go
+++ b/v2/integration/vms_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestVmCreation(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "creation-test-" + uuid.Must(uuid.NewV4()).String()
@@ -27,7 +26,6 @@ func TestVmCreation(t *testing.T) {
 }
 
 func TestVmDeletion(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "deletion-test-" + uuid.Must(uuid.NewV4()).String()
@@ -49,7 +47,6 @@ func TestVmDeletion(t *testing.T) {
 }
 
 func TestVmStart(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "start-test-" + uuid.Must(uuid.NewV4()).String()
@@ -76,7 +73,6 @@ func TestVmStart(t *testing.T) {
 }
 
 func TestVmHardShutdown(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "hard-shutdown-test-" + uuid.Must(uuid.NewV4()).String()
@@ -101,7 +97,6 @@ func TestVmHardShutdown(t *testing.T) {
 }
 
 func TestVmCleanShutdown(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "clean-shutdown-test-" + uuid.Must(uuid.NewV4()).String()
@@ -129,7 +124,6 @@ func TestVmCleanShutdown(t *testing.T) {
 }
 
 func TestVmCleanReboot(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "clean-reboot-test-" + uuid.Must(uuid.NewV4()).String()
@@ -157,7 +151,6 @@ func TestVmCleanReboot(t *testing.T) {
 }
 
 func TestVmHardReboot(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "hard-reboot-test-" + uuid.Must(uuid.NewV4()).String()
@@ -182,7 +175,6 @@ func TestVmHardReboot(t *testing.T) {
 }
 
 func TestVmPauseUnpause(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "pause-test-" + uuid.Must(uuid.NewV4()).String()
@@ -217,7 +209,6 @@ func TestVmPauseUnpause(t *testing.T) {
 }
 
 func TestVmSuspendResume(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "suspend-test-" + uuid.Must(uuid.NewV4()).String()
@@ -254,7 +245,6 @@ func TestVmSuspendResume(t *testing.T) {
 }
 
 func TestVmSnapshot(t *testing.T) {
-	t.Parallel()
 	ctx, client, testPrefix := SetupTestContext(t)
 
 	vmName := testPrefix + "snapshot-test-" + uuid.Must(uuid.NewV4()).String()
@@ -353,10 +343,12 @@ func TestVMGetVDIs(t *testing.T) {
 			{
 				NameLabel: ptr(testPrefix + "vm-vdi-1"),
 				Size:      ptr(int64(1 * units.GB)),
+				SR:        ptr(intTests.testSR.ID),
 			},
 			{
 				NameLabel: ptr(testPrefix + "vm-vdi-2"),
 				Size:      ptr(int64(512 * units.MB)),
+				SR:        ptr(intTests.testSR.ID),
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes the integration tests.

- Use v2 SDK to cleanup VDIs.
- Use v2 SDK to create network for test.
- Fix SR tests that return 404 error.
- Fix VDI & VDB tests when VM template default SR and test SR are different.
- Remove test parallelism for VMs and VDIs tests to avoid timeout issue with a slow Xen Orchestra.
- Update doc to specify that the test network must be a non-VLAN network.
