### PR TITLE
Fix/template value

### DIFF
--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -46,6 +46,10 @@ var disklessTestTemplate Template
 var accVm Vm
 
 func TestMain(m *testing.M) {
+	if !hasIntegrationTestEnv() {
+		os.Exit(m.Run())
+	}
+
 	FindPoolForTests(&accTestPool)
 	FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
 	FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
@@ -61,4 +65,25 @@ func TestMain(m *testing.M) {
 	_ = RemoveNetworksWithNamePrefixForTests(integrationTestPrefix)("")
 
 	os.Exit(code)
+}
+
+func hasIntegrationTestEnv() bool {
+	_, hasToken := os.LookupEnv("XOA_TOKEN")
+	_, hasUser := os.LookupEnv("XOA_USER")
+	_, hasPassword := os.LookupEnv("XOA_PASSWORD")
+
+	required := []string{
+		"XOA_URL",
+		"XOA_POOL",
+		"XOA_TEMPLATE",
+		"XOA_DISKLESS_TEMPLATE",
+	}
+
+	for _, name := range required {
+		if _, found := os.LookupEnv(name); !found {
+			return false
+		}
+	}
+
+	return hasToken || (hasUser && hasPassword)
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -126,7 +126,8 @@ type Vm struct {
 	VBDs               []string               `json:"$VBDs"`
 	VirtualizationMode string                 `json:"virtualizationMode"`
 	PoolId             string                 `json:"$poolId"`
-	Template           string                 `json:"template"`
+	Template           string                 `json:"template,omitempty"`
+	Creation           Creation               `json:"creation,omitempty"`
 	AutoPoweron        bool                   `json:"auto_poweron"`
 	HA                 string                 `json:"high_availability"`
 	CloudConfig        string                 `json:"cloudConfig"`
@@ -158,6 +159,37 @@ type Vm struct {
 type Installation struct {
 	Method     string `json:"-"`
 	Repository string `json:"-"`
+}
+
+type Creation struct {
+	Date     string                 `json:"date,omitempty"`
+	Template string                 `json:"template,omitempty"`
+	User     string                 `json:"user,omitempty"`
+	Raw      map[string]interface{} `json:"-"`
+}
+
+func (c *Creation) UnmarshalJSON(data []byte) error {
+	type creationAlias Creation
+
+	if err := json.Unmarshal(data, (*creationAlias)(c)); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &c.Raw)
+}
+
+func (v *Vm) UnmarshalJSON(data []byte) error {
+	type vmAlias Vm // create an alias to avoid infinite recursion
+
+	if err := json.Unmarshal(data, (*vmAlias)(v)); err != nil {
+		return err
+	}
+
+	if v.Template == "" {
+		v.Template = v.Creation.Template
+	}
+
+	return nil
 }
 
 func (v Vm) Compare(obj interface{}) bool {

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -8,6 +8,9 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var vmObjectData string = `
@@ -393,4 +396,63 @@ func Test_warnOnInvalidCloudConfigRecognizesMultipartMIME(t *testing.T) {
 	if strings.Contains(logBuf.String(), "WARN") {
 		t.Errorf("multipart MIME archives should be recognized as valid cloud config")
 	}
+}
+
+func TestUnmarshalJSONVM(t *testing.T) {
+	testParams := []struct {
+		name          string
+		templateValue string
+		creationValue string
+		expectedValue string
+	}{
+		{"both empty", "", "", ""},
+		{"only creation", "", "template-from-creation", "template-from-creation"},
+		{"only template", "template-from-field", "", "template-from-field"},
+		{"both set", "template-from-field", "template-from-creation", "template-from-field"},
+	}
+
+	for _, p := range testParams {
+		t.Run(p.name, func(t *testing.T) {
+			data := fmt.Appendf(nil, `{
+				"id": "vm-id",
+				"name_label": "vm-name",
+				"type": "VM",
+				"template": %q,
+				"creation": {
+					"template": %q
+				}
+			}`, p.templateValue, p.creationValue)
+
+			var unmarshaledVm Vm
+			err := json.Unmarshal(data, &unmarshaledVm)
+
+			require.NoError(t, err, "failed to unmarshal vm")
+			assert.Equal(t, p.expectedValue, unmarshaledVm.Template, "expected template to be '%s', got '%s'", p.expectedValue, unmarshaledVm.Template)
+		})
+	}
+}
+
+func TestCreationUnmarshalJSONRaw(t *testing.T) {
+	const date = "2026-07-15"
+	const template = "template-id"
+	const user = "user-id"
+	customKey := map[string]interface{}{"enabled": true}
+
+	data := fmt.Appendf(nil, `{
+		"date": %q,
+		"template": %q,
+		"user": %q,
+		"customKey": {"enabled": true}
+	}`, date, template, user)
+
+	var creation Creation
+	require.NoError(t, json.Unmarshal(data, &creation))
+
+	assert.Equal(t, date, creation.Date)
+	assert.Equal(t, template, creation.Template)
+	assert.Equal(t, user, creation.User)
+	assert.Equal(t, date, creation.Raw["date"])
+	assert.Equal(t, template, creation.Raw["template"])
+	assert.Equal(t, user, creation.Raw["user"])
+	assert.Equal(t, customKey, creation.Raw["customKey"])
 }

--- a/pkg/payloads/vm.go
+++ b/pkg/payloads/vm.go
@@ -67,6 +67,38 @@ type VM struct {
 	Container          uuid.UUID         `json:"$container,omitempty"`
 	Snapshots          []uuid.UUID       `json:"snapshots,omitempty"`
 	Type               ResourceType      `json:"type"`
+	Creation           Creation          `json:"creation,omitempty"`
+}
+
+type Creation struct {
+	Date     string                 `json:"date,omitempty"`
+	Template uuid.UUID              `json:"template,omitempty"`
+	User     string                 `json:"user,omitempty"`
+	Raw      map[string]interface{} `json:"-"`
+}
+
+func (c *Creation) UnmarshalJSON(data []byte) error {
+	type creationAlias Creation
+
+	if err := json.Unmarshal(data, (*creationAlias)(c)); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &c.Raw)
+}
+
+func (v *VM) UnmarshalJSON(data []byte) error {
+	type vmAlias VM
+
+	if err := json.Unmarshal(data, (*vmAlias)(v)); err != nil {
+		return err
+	}
+
+	if v.Template == uuid.Nil {
+		v.Template = v.Creation.Template
+	}
+
+	return nil
 }
 
 type Memory struct {

--- a/pkg/payloads/vm_test.go
+++ b/pkg/payloads/vm_test.go
@@ -1,0 +1,88 @@
+package payloads
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVM_UnmarshalJSON_TemplateFromCreation(t *testing.T) {
+	templateFromField := uuid.Must(uuid.FromString("11111111-2222-3333-4444-555555555555"))
+	templateFromCreation := uuid.Must(uuid.FromString("66666666-7777-8888-9999-aaaaaaaaaaaa"))
+
+	testParams := []struct {
+		name     string
+		template *uuid.UUID
+		creation *uuid.UUID
+		expected uuid.UUID
+	}{
+		{"both empty", nil, nil, uuid.Nil},
+		{"only creation", nil, &templateFromCreation, templateFromCreation},
+		{"only template", &templateFromField, nil, templateFromField},
+		{"both set", &templateFromField, &templateFromCreation, templateFromField},
+	}
+
+	for _, p := range testParams {
+		t.Run(p.name, func(t *testing.T) {
+			payload := []byte(fmt.Sprintf(`{
+				"id": "00000000-0000-0000-0000-000000000001",
+				"name_label": "vm-test",
+				"power_state": "Running",
+				"memory": {"size": 1024},
+				"CPUs": {"number": 2},
+				"type": "VM"%s%s
+			}`, templateJSON(p.template), creationJSON(p.creation)))
+
+			var vm VM
+			require.NoError(t, json.Unmarshal(payload, &vm))
+			assert.Equal(t, p.expected, vm.Template)
+		})
+	}
+}
+
+func TestCreation_UnmarshalJSON_Raw(t *testing.T) {
+	const date = "2026-07-15"
+	const template = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+	const user = "user-id"
+	customKey := map[string]interface{}{"enabled": true}
+
+	data := fmt.Appendf(nil, `{
+		"date": %q,
+		"template": %q,
+		"user": %q,
+		"customKey": {"enabled": true}
+	}`, date, template, user)
+
+	var creation Creation
+	require.NoError(t, json.Unmarshal(data, &creation))
+
+	assert.Equal(t, template, creation.Template.String())
+	assert.Equal(t, date, creation.Raw["date"])
+	assert.Equal(t, template, creation.Raw["template"])
+	assert.Equal(t, user, creation.Raw["user"])
+	assert.Equal(t, customKey, creation.Raw["customKey"])
+}
+
+func templateJSON(template *uuid.UUID) string {
+	if template == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`,
+				"template": %q`, template.String())
+}
+
+func creationJSON(template *uuid.UUID) string {
+	if template == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`,
+				"creation": {
+					"template": %q
+				}`, template.String())
+}


### PR DESCRIPTION
This PR fix the fact that on our two clients versions, template is always empty. This is due to the xo api not having explicit template field, but creation.template.

This cause other bugs into xo terraform provider about importing VMs, and has goal to fix them.

I already tested this pr into xo tf provider and with a script, and I got the template id that i couldn't have before