### PR TITLE
feat(v2/client): make HTTP client timeout configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ integration_tests.log
 logs
 
 vscode/
+
+# Auto-generated Swagger spec
+swagger.json

--- a/docs/v2/01-overview.md
+++ b/docs/v2/01-overview.md
@@ -78,6 +78,7 @@ The SDK uses the following environment variables for configuration:
 - `XOA_DEVELOPMENT`: Set to "true" to enable development mode with additional logging
 - `XOA_RETRY_MODE`: Retry strategy ("none" or "backoff")
 - `XOA_RETRY_MAX_TIME`: Maximum time to wait between retries (default: 5 minutes)
+- `XOA_CLIENT_TIMEOUT`: HTTP client timeout (default: 30 seconds)
 
 
 ### Custom Logging Sinks

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	Development  bool
 	RetryMode    core.RetryMode
 	RetryMaxTime time.Duration
+	// ClientTimeout is the HTTP client timeout. Defaults to 30 seconds.
+	ClientTimeout time.Duration
 	// OutputPaths and ErrorOutputPaths for the logger.
 	LogOutputPaths      []string
 	LogErrorOutputPaths []string
@@ -54,6 +56,7 @@ const (
 // - XOA_DEVELOPMENT: whether to enable development mode.
 // - XOA_RETRY_MODE: the retry mode to use. Defaults to "none". Valid values are "none", "backoff".
 // - XOA_RETRY_MAX_TIME: the maximum time to wait between retries. Defaults to 5 minutes.
+// - XOA_CLIENT_TIMEOUT: the HTTP client timeout. Defaults to 30 seconds.
 //
 // If any of the required environment variables are not set, New will return an error.
 func New() (*Config, error) {
@@ -89,6 +92,16 @@ func New() (*Config, error) {
 		}
 	}
 
+	clientTimeout := 30 * time.Second
+	if v := os.Getenv("XOA_CLIENT_TIMEOUT"); v != "" {
+		duration, err := time.ParseDuration(v)
+		if err == nil {
+			clientTimeout = duration
+		} else {
+			fmt.Println("[ERROR] failed to parse XOA_CLIENT_TIMEOUT, using default 30s")
+		}
+	}
+
 	insecureStr := os.Getenv("XOA_INSECURE")
 	insecure := false
 	if insecureStr != "" {
@@ -109,6 +122,7 @@ func New() (*Config, error) {
 		Development:         development,
 		RetryMode:           retryMode,
 		RetryMaxTime:        retryMaxTime,
+		ClientTimeout:       clientTimeout,
 		LogOutputPaths:      []string{"stdout"},
 		LogErrorOutputPaths: []string{"stderr"},
 	}, nil
@@ -134,6 +148,11 @@ func NewWithValues(config *Config) (*Config, error) {
 		return nil, errors.New(errMissingAuthInfo)
 	}
 
+	clientTimeout := config.ClientTimeout
+	if clientTimeout == 0 {
+		clientTimeout = 30 * time.Second
+	}
+
 	return &Config{
 		Url:                 config.Url,
 		Username:            config.Username,
@@ -142,6 +161,7 @@ func NewWithValues(config *Config) (*Config, error) {
 		InsecureSkipVerify:  config.InsecureSkipVerify,
 		RetryMode:           config.RetryMode,
 		RetryMaxTime:        config.RetryMaxTime,
+		ClientTimeout:       clientTimeout,
 		Development:         config.Development,
 		LogOutputPaths:      config.LogOutputPaths,
 		LogErrorOutputPaths: config.LogErrorOutputPaths,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientTimeoutEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		unset   bool
+		want    time.Duration
+	}{
+		{
+			name:  "not set defaults to 30s",
+			unset: true,
+			want:  30 * time.Second,
+		},
+		{
+			name:    "60s",
+			timeout: "60s",
+			want:    1 * time.Minute,
+		},
+		{
+			name:    "5s",
+			timeout: "5s",
+			want:    5 * time.Second,
+		},
+		{
+			name:    "2m",
+			timeout: "2m",
+			want:    2 * time.Minute,
+		},
+		{
+			name:    "invalid value falls back to 30s",
+			timeout: "not-a-duration",
+			want:    30 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Required env vars for New()
+			t.Setenv("XOA_URL", "http://example.com")
+			t.Setenv("XOA_TOKEN", "abc")
+
+			if tc.unset {
+				os.Unsetenv("XOA_CLIENT_TIMEOUT")
+			} else {
+				t.Setenv("XOA_CLIENT_TIMEOUT", tc.timeout)
+			}
+
+			cfg, _ := New()
+			assert.Equal(t, tc.want, cfg.ClientTimeout)
+		})
+	}
+}

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -77,9 +77,14 @@ func New(config *config.Config) (*Client, error) {
 		InsecureSkipVerify: config.InsecureSkipVerify,
 	}
 
+	clientTimeout := config.ClientTimeout
+	if clientTimeout == 0 {
+		clientTimeout = 30 * time.Second
+	}
+
 	httpClient := &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		Timeout:   clientTimeout,
 	}
 
 	client := &Client{

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -7,7 +7,10 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vatesfr/xenorchestra-go-sdk/pkg/config"
 )
 
@@ -16,18 +19,59 @@ var ctx = context.Background()
 const (
 	restPath       = "/rest/v0"
 	testTokenValue = "test-token"
+	testToken      = "abc"
 )
 
 func TestNew(t *testing.T) {
-	_, err := New(&config.Config{Url: "://invalid-url", Token: "abc"})
-	if err == nil {
-		t.Error("Expected error for invalid URL, got nil")
-	}
+	t.Run("InvalidURL", func(t *testing.T) {
+		_, err := New(&config.Config{Url: "://invalid-url", Token: testToken})
+		assert.Error(t, err)
+	})
 
-	_, err = New(&config.Config{Url: "http://example.com", Token: "abc"})
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	t.Run("ValidTokenAuth", func(t *testing.T) {
+		_, err := New(&config.Config{Url: "http://example.com", Token: testToken})
+		assert.NoError(t, err)
+	})
+
+	t.Run("DefaultClientTimeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client, err := New(&config.Config{
+			Url:   server.URL,
+			Token: testToken,
+			// ClientTimeout not set – should default to 30s
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, client.HttpClient.Timeout)
+	})
+
+	t.Run("CustomClientTimeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		for _, tc := range []struct {
+			name    string
+			timeout time.Duration
+		}{
+			{"1min", 1 * time.Minute},
+			{"5s", 5 * time.Second},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				client, err := New(&config.Config{
+					Url:           server.URL,
+					Token:         testToken,
+					ClientTimeout: tc.timeout,
+				})
+				require.NoError(t, err)
+				assert.Equal(t, tc.timeout, client.HttpClient.Timeout)
+			})
+		}
+	})
 }
 
 func TestAuthenticate(t *testing.T) {
@@ -64,24 +108,15 @@ func TestAuthenticate(t *testing.T) {
 		Username: "testuser",
 		Password: "testpass",
 	})
-
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	if client.AuthToken != testTokenValue {
-		t.Errorf("Expected token 'test-token', got '%s'", client.AuthToken)
-	}
+	require.NoError(t, err)
+	assert.EqualValues(t, testTokenValue, client.AuthToken)
 
 	_, err = New(&config.Config{
 		Url:      server.URL,
 		Username: "wrong",
 		Password: "wrong",
 	})
-
-	if err == nil {
-		t.Error("Expected authentication error, got nil")
-	}
+	assert.Error(t, err)
 }
 
 func TestDo(t *testing.T) {
@@ -126,28 +161,18 @@ func TestDo(t *testing.T) {
 		Result string `json:"result"`
 	}
 	err := client.get(ctx, "test", nil, &getResult)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	if getResult.Result != "success" {
-		t.Errorf("Expected result 'success', got '%s'", getResult.Result)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "success", getResult.Result)
 
 	var postResult struct {
 		ID string `json:"id"`
 	}
 	err = client.post(ctx, "test", map[string]interface{}{"key": "value"}, &postResult)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	if postResult.ID != "123" {
-		t.Errorf("Expected ID '123', got '%s'", postResult.ID)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "123", postResult.ID)
 
 	err = client.post(ctx, "error", nil, nil)
-	if err == nil {
-		t.Error("Expected error, got nil")
-	}
+	assert.Error(t, err)
 }
 
 func TestTypedGet(t *testing.T) {
@@ -182,12 +207,7 @@ func TestTypedGet(t *testing.T) {
 	var result TestResult
 
 	err := TypedGet(ctx, client, "test", &params, &result)
-
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	if result.Name != "test-item" || result.Value != 123 {
-		t.Errorf("Expected result {Name:'test-item', Value:123}, got %+v", result)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "test-item", result.Name)
+	assert.Equal(t, 123, result.Value)
 }


### PR DESCRIPTION
Add ClientTimeout field to Config, reading XOA_CLIENT_TIMEOUT env var (default 30s). Replace the hardcoded 30s timeout in the v2 client with the value from config.

- Add config-level tests for env var parsing
- Add client-level tests for default and custom timeout
- Update docs/v2/01-overview.md env vars list
- Fix misleading test subtest name and lint issues