### PR TITLE
feat(vm): support the share flag for VMs

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -132,6 +132,7 @@ type Vm struct {
 	HA                 string                 `json:"high_availability"`
 	CloudConfig        string                 `json:"cloudConfig"`
 	ResourceSet        *FlatResourceSet       `json:"resourceSet"`
+	Share              *bool                  `json:"share,omitempty"`
 	SecureBoot         bool                   `json:"secureBoot,omitempty"`
 	Tags               []string               `json:"tags"`
 	Videoram           Videoram               `json:"videoram,omitempty"`
@@ -440,6 +441,10 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		params["resourceSet"] = resourceSet
 	}
 
+	if vmReq.Share != nil {
+		params["share"] = *vmReq.Share
+	}
+
 	cloudNetworkConfig := vmReq.CloudNetworkConfig
 	if cloudNetworkConfig != "" {
 		params["networkConfig"] = cloudNetworkConfig
@@ -530,9 +535,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		// https://github.com/xapi-project/xen-api/blob/889b83c47d46c4df65fe58b01caed284dab8dc93
 		// /ocaml/idl/datamodel_vm.ml#L1168
 
-		// share relates to resource sets. This can be accomplished with the resource set resource so
-		// supporting it isn't necessary
-
 		// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
 	}
@@ -564,6 +566,10 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 
 	if vmReq.ResourceSet != nil {
 		params["resourceSet"] = vmReq.ResourceSet
+	}
+
+	if vmReq.Share != nil {
+		params["share"] = *vmReq.Share
 	}
 
 	if len(vmReq.XenstoreData) > 0 {

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -248,6 +248,54 @@ func TestFlatResourceSetUnmarshalling(t *testing.T) {
 	}
 }
 
+func TestShareFieldMarshalling(t *testing.T) {
+	// Unmarshal a VM with share=true
+	var vmObj Vm
+	if err := json.Unmarshal([]byte(`{"type": "VM", "share": true}`), &vmObj); err != nil {
+		t.Fatalf("failed to unmarshal vm with share: %v", err)
+	}
+	if vmObj.Share == nil || *vmObj.Share != true {
+		t.Fatalf("expected Share to be true, got %v", vmObj.Share)
+	}
+
+	// share=false must round-trip as an explicit false, not be dropped
+	var vmFalse Vm
+	if err := json.Unmarshal([]byte(`{"type": "VM", "share": false}`), &vmFalse); err != nil {
+		t.Fatalf("failed to unmarshal vm with share=false: %v", err)
+	}
+	if vmFalse.Share == nil || *vmFalse.Share != false {
+		t.Fatalf("expected Share to be false, got %v", vmFalse.Share)
+	}
+
+	// A VM without a share attribute keeps Share nil
+	var vmNoShare Vm
+	if err := json.Unmarshal([]byte(`{"type": "VM"}`), &vmNoShare); err != nil {
+		t.Fatalf("failed to unmarshal vm without share: %v", err)
+	}
+	if vmNoShare.Share != nil {
+		t.Fatalf("expected Share to be nil, got %v", *vmNoShare.Share)
+	}
+
+	// A nil pointer is omitted from marshalled output (omitempty)
+	b, err := json.Marshal(Vm{Share: nil})
+	if err != nil {
+		t.Fatalf("failed to marshal vm without share: %v", err)
+	}
+	if strings.Contains(string(b), `"share"`) {
+		t.Errorf("expected no `share` field in %s", b)
+	}
+
+	// A set pointer marshals to the underlying boolean
+	truth := true
+	b, err = json.Marshal(Vm{Share: &truth})
+	if err != nil {
+		t.Fatalf("failed to marshal vm with share: %v", err)
+	}
+	if !strings.Contains(string(b), `"share":true`) {
+		t.Errorf("expected `share: true` in %s", b)
+	}
+}
+
 func TestUpdateVmWithUpdatesThatRequireHalt(t *testing.T) {
 	c, err := NewClient(GetConfigFromEnv())
 	if err != nil {


### PR DESCRIPTION
Adds a `Share` field to the `Vm` struct to expose XO's `share` flag.

When set, the field is forwarded as the `share` parameter on both
`CreateVm` and `UpdateVm`. Because XO does not store the flag as a
persistent VM attribute, it is modelled as `*bool` so that:

- `nil` (unspecified) leaves the request unchanged and the field is
  omitted from marshalled output (`omitempty`)
- an explicit `false` still round-trips and is sent, rather than being
  dropped like a plain bool would be
- `true` grants admin access to the VM's resource-set members

- Remove the outdated "share isn't necessary" comment in `UpdateVm`
- Add unit tests covering marshal/unmarshal of the share field